### PR TITLE
Feature: WebSocket 및 Redis 초기 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/muzusi/infrastructure/config/RedisConfig.java
+++ b/src/main/java/muzusi/infrastructure/config/RedisConfig.java
@@ -1,0 +1,76 @@
+package muzusi.infrastructure.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    @Value("${spring.data.redis.port}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(host, port);
+
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer() );
+
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            ChannelTopic chart,
+            ChannelTopic koreaStockPulse,
+            ChannelTopic trade,
+            ChannelTopic stockRanking
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory());
+
+        return container;
+    }
+
+    @Bean(name = "chart")
+    public ChannelTopic chart() {
+        return new ChannelTopic("chart");
+    }
+
+    @Bean(name = "koreaStockPulse")
+    public ChannelTopic koreaStockPulse() {
+        return new ChannelTopic("korea-stock-pulse");
+    }
+
+    @Bean(name = "trade")
+    public ChannelTopic trade(){
+        return new ChannelTopic("trade");
+    }
+
+    @Bean(name = "stockRanking")
+    public ChannelTopic ranking(){
+        return new ChannelTopic("stock-ranking");
+    }
+}

--- a/src/main/java/muzusi/infrastructure/config/WebSocketConfig.java
+++ b/src/main/java/muzusi/infrastructure/config/WebSocketConfig.java
@@ -1,0 +1,26 @@
+package muzusi.infrastructure.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub");
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/stomp")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,11 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
 jwt:
   secret: ${JWT_KEY:exampleSecretKeyForMuzusiSystemAccessSecretKeyTestForPadding}
   access-expiration: ${JWT_ACCESS_EXPIRATION:1800000}
@@ -36,3 +41,4 @@ oauth2:
     clientSecret: ${NAVER_CLIENT_SECRET}
     redirectUri: ${NAVER_REDIRECT_URL}
     getUserInfoUri: https://openapi.naver.com/v1/nid/me
+


### PR DESCRIPTION
## 배경
- #16 
- Redis Message Broker 도입을 위한 Redis 기초 설정

## 작업 사항
- WebSocketConfig 파일 추가
- RedisConfig 파일 추가
- ChannelTopic 등록
   - `chart`:  특정 주식 차트
   - `korea-stock-pulse`: 코스피 및 코스닥 지수
   - `trade`: 거래 정보(호가창 거래 정보)
   - `stock-ranking`: 급상승, 거래량 등 주식 순위 정보

## 추가 논의 및 기타 사항
- Redis 상에 적용되는 Topic 이름은 Ke-bab 케이스 적용하여 작성하였습니다.
- 현재 각 DTO에 대한 정의 및 주식 API 연결이 되어 있지 않아 각 채널 별 `MessageListener`는 생성하지 않았습니다. 차후 적용 시 `RedisMessageListenerContainer`에 해당 리스너 클래스 주입 및 적용시키도록 하겠습니다.