### PR TITLE
Fix: 에러 코드 응답 시 출력 오류로 인한 수정

### DIFF
--- a/src/main/java/muzusi/domain/post/exception/PostErrorType.java
+++ b/src/main/java/muzusi/domain/post/exception/PostErrorType.java
@@ -12,7 +12,7 @@ public enum PostErrorType implements BaseErrorType {
     ;
 
     private final HttpStatus status;
-    private final int code;
+    private final String code;
     private final String message;
 
     @Override
@@ -21,7 +21,7 @@ public enum PostErrorType implements BaseErrorType {
     }
 
     @Override
-    public int getCode() {
+    public String getCode() {
         return code;
     }
 

--- a/src/main/java/muzusi/domain/stock/exception/StockErrorType.java
+++ b/src/main/java/muzusi/domain/stock/exception/StockErrorType.java
@@ -12,7 +12,7 @@ public enum StockErrorType implements BaseErrorType {
     ;
 
     private final HttpStatus status;
-    private final int code;
+    private final String code;
     private final String message;
 
     @Override
@@ -21,7 +21,7 @@ public enum StockErrorType implements BaseErrorType {
     }
 
     @Override
-    public int getCode() {
+    public String getCode() {
         return code;
     }
 

--- a/src/main/java/muzusi/domain/user/exception/UserErrorType.java
+++ b/src/main/java/muzusi/domain/user/exception/UserErrorType.java
@@ -10,17 +10,12 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorType implements BaseErrorType {
 
-    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, 1001, "사용 기한이 만료된 토큰입니다."),
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, 1002, "사용 기한이 만료된 토큰입니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 1003, "유효하지 않은 토큰입니다."),
-    MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, 1004, "형식이 잘못된 토큰입니다."),
-
-    UN_AUTHORIZED(HttpStatus.FORBIDDEN, 1005, "허용되지 않은 접근입니다."),
-    UNSUPPORTED_SOCIAL_LOGIN(HttpStatus.BAD_REQUEST, 1006, "지원하지 않는 소셜 로그인입니다.")
+    UN_AUTHORIZED(HttpStatus.FORBIDDEN, "1005", "허용되지 않은 접근입니다."),
+    UNSUPPORTED_SOCIAL_LOGIN(HttpStatus.BAD_REQUEST, "1006", "지원하지 않는 소셜 로그인입니다.")
     ;
 
     private final HttpStatus status;
-    private final int code;
+    private final String code;
     private final String message;
 
     @Override
@@ -29,7 +24,7 @@ public enum UserErrorType implements BaseErrorType {
     }
 
     @Override
-    public int getCode() {
+    public String getCode() {
         return code;
     }
 

--- a/src/main/java/muzusi/global/response/error/ErrorResponse.java
+++ b/src/main/java/muzusi/global/response/error/ErrorResponse.java
@@ -5,7 +5,7 @@ import muzusi.global.response.error.type.BaseErrorType;
 
 @Builder
 public record ErrorResponse(
-        int code,
+        String code,
         String message
 ) {
     public static ErrorResponse from(BaseErrorType error){

--- a/src/main/java/muzusi/global/response/error/type/BaseErrorType.java
+++ b/src/main/java/muzusi/global/response/error/type/BaseErrorType.java
@@ -4,6 +4,6 @@ import org.springframework.http.HttpStatus;
 
 public interface BaseErrorType {
     HttpStatus getStatus();
-    int getCode();
+    String getCode();
     String getMessage();
 }

--- a/src/main/java/muzusi/global/response/error/type/CommonErrorType.java
+++ b/src/main/java/muzusi/global/response/error/type/CommonErrorType.java
@@ -9,18 +9,18 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CommonErrorType implements BaseErrorType {
 
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, 0001, "요청을 실패하였습니다."),
-    NOT_FOUND(HttpStatus.NOT_FOUND, 0002, "조회에 실패하였습니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 0003, "서버 내부 에러입니다. 관리자에게 문의하세요."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "0001", "요청을 실패하였습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "0002", "조회에 실패하였습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "0003", "서버 내부 에러입니다. 관리자에게 문의하세요."),
 
-    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, 0004, "Access Token이 만료되었습니다."),
-    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, 0005, "Access Token이 잘못되었습니다."),
-    INVALID_TOKEN_SIGNATURE(HttpStatus.UNAUTHORIZED, 0006, "Access Token의 서명이 잘못되었습니다."),
-    UNKNOWN_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, 0007, "알 수 없는 토큰 에러입니다.")
+    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "0004", "Access Token이 만료되었습니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "0005", "Access Token이 잘못되었습니다."),
+    INVALID_TOKEN_SIGNATURE(HttpStatus.UNAUTHORIZED, "0006", "Access Token의 서명이 잘못되었습니다."),
+    UNKNOWN_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "0007", "알 수 없는 토큰 에러입니다.")
     ;
 
     private final HttpStatus status;
-    private final int code;
+    private final String code;
     private final String message;
 
     @Override
@@ -29,7 +29,7 @@ public enum CommonErrorType implements BaseErrorType {
     }
 
     @Override
-    public int getCode() {
+    public String getCode() {
         return code;
     }
 


### PR DESCRIPTION
## 배경
- 앞자리가 0으로 시작하는 에러 코드 반환 시 출력 오류로 인한 code 필드 타입 수정

## 작업 사항
- `ErrorType` 내 `int code` → `String code` 
- 에러 코드 타입 수정에 따른 `ErrorResponse` 내 정적 팩토리 메서드 `.of(...)` 수정
- [기타] `UserErrorType` 내 인증 관련 에러 코드 삭제
