### PR TITLE
Feature: 회원가입 구현

### DIFF
--- a/src/main/java/muzusi/application/auth/dto/SignUpDto.java
+++ b/src/main/java/muzusi/application/auth/dto/SignUpDto.java
@@ -1,0 +1,6 @@
+package muzusi.application.auth.dto;
+
+public record SignUpDto(
+        String nickname
+) {
+}

--- a/src/main/java/muzusi/application/auth/dto/SignUpDto.java
+++ b/src/main/java/muzusi/application/auth/dto/SignUpDto.java
@@ -1,6 +1,10 @@
 package muzusi.application.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "SignUpDto", description = "회원가입 DTO")
 public record SignUpDto(
+        @Schema(description = "낙네임", example = "test")
         String nickname
 ) {
 }

--- a/src/main/java/muzusi/application/auth/service/AuthService.java
+++ b/src/main/java/muzusi/application/auth/service/AuthService.java
@@ -4,18 +4,23 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import muzusi.application.auth.dto.LoginDto;
 import muzusi.application.auth.dto.TokenDto;
+import muzusi.application.auth.dto.UserInfoDto;
 import muzusi.application.auth.dto.UserStatusDto;
 import muzusi.application.auth.helper.JwtHelper;
 import muzusi.application.auth.service.client.OAuthClient;
 import muzusi.application.auth.service.client.OAuthClientFactory;
+import muzusi.domain.user.entity.User;
+import muzusi.domain.user.service.UserService;
 import muzusi.domain.user.type.OAuthPlatform;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
     private final OAuthClientFactory oAuthClientFactory;
     private final JwtHelper jwtHelper;
+    private final UserService userService;
 
     /**
      * 서비스 로그인을 위한 메서드
@@ -24,13 +29,48 @@ public class AuthService {
      * @param code : 플랫폼의 인가 코드
      * @return : jwt token, 최초 가입 여부
      */
+    @Transactional
     public LoginDto signIn(OAuthPlatform platform, String code) {
         OAuthClient oAuthClient = oAuthClientFactory.getPlatformService(platform);
 
-        UserStatusDto userStatusDto = oAuthClient.login(code);
+        UserInfoDto userInfoDto = oAuthClient.fetchUserInfoFromPlatform(code);
+        UserStatusDto userStatusDto = findOrRegisterUser(platform, userInfoDto.id());
         TokenDto tokenDto = jwtHelper.createToken(userStatusDto.user());
 
         return LoginDto.of(tokenDto, userStatusDto.isRegistered());
+    }
+
+    /**
+     * 사용자 상태 확인 및 등록
+     *
+     * @param platform : OAuth 플랫폼
+     * @param platformUserId : 플랫폼 사용자 ID
+     * @return : 사용자 상태 정보
+     */
+    private UserStatusDto findOrRegisterUser(OAuthPlatform platform, String platformUserId) {
+        String username = platform + "_" + platformUserId;
+
+        return userService.readByUsername(username)
+                .map(user -> UserStatusDto.of(user, true))
+                .orElseGet(() -> registerNewUser(username, platform));
+    }
+
+    /**
+     * 신규 사용자 등록
+     *
+     * @param username : 사용자 이름
+     * @param platform : OAuth 플랫폼
+     * @return : 등록된 사용자
+     */
+    private UserStatusDto registerNewUser(String username, OAuthPlatform platform) {
+        User newUser = userService.save(
+                User.builder()
+                        .username(username)
+                        .nickname(username)
+                        .platform(platform)
+                        .build()
+        );
+        return UserStatusDto.of(newUser, false);
     }
 
     /**

--- a/src/main/java/muzusi/application/auth/service/AuthService.java
+++ b/src/main/java/muzusi/application/auth/service/AuthService.java
@@ -3,6 +3,7 @@ package muzusi.application.auth.service;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import muzusi.application.auth.dto.LoginDto;
+import muzusi.application.auth.dto.SignUpDto;
 import muzusi.application.auth.dto.TokenDto;
 import muzusi.application.auth.dto.UserInfoDto;
 import muzusi.application.auth.dto.UserStatusDto;
@@ -10,8 +11,10 @@ import muzusi.application.auth.helper.JwtHelper;
 import muzusi.application.auth.service.client.OAuthClient;
 import muzusi.application.auth.service.client.OAuthClientFactory;
 import muzusi.domain.user.entity.User;
+import muzusi.domain.user.exception.UserErrorType;
 import muzusi.domain.user.service.UserService;
 import muzusi.domain.user.type.OAuthPlatform;
+import muzusi.global.exception.CustomException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -71,6 +74,14 @@ public class AuthService {
                         .build()
         );
         return UserStatusDto.of(newUser, false);
+    }
+
+    @Transactional
+    public void signUp(Long userId, SignUpDto signUpDto) {
+        User foundUser = userService.readById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
+
+        userService.update(foundUser, signUpDto.nickname());
     }
 
     /**

--- a/src/main/java/muzusi/application/auth/service/AuthService.java
+++ b/src/main/java/muzusi/application/auth/service/AuthService.java
@@ -76,6 +76,12 @@ public class AuthService {
         return UserStatusDto.of(newUser, false);
     }
 
+    /**
+     * 회원가입 메서드
+     *
+     * @param userId : 사용자 PK값
+     * @param signUpDto : 회원정보 dto
+     */
     @Transactional
     public void signUp(Long userId, SignUpDto signUpDto) {
         User foundUser = userService.readById(userId)

--- a/src/main/java/muzusi/application/auth/service/client/KakaoClient.java
+++ b/src/main/java/muzusi/application/auth/service/client/KakaoClient.java
@@ -3,11 +3,7 @@ package muzusi.application.auth.service.client;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import muzusi.application.auth.dto.UserStatusDto;
 import muzusi.application.auth.dto.UserInfoDto;
-import muzusi.domain.user.entity.User;
-import muzusi.domain.user.service.UserService;
-import muzusi.domain.user.type.OAuthPlatform;
 import muzusi.global.exception.CustomException;
 import muzusi.global.response.error.type.CommonErrorType;
 import muzusi.infrastructure.properties.KakaoProperties;
@@ -17,7 +13,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
@@ -25,7 +20,6 @@ import org.springframework.web.client.RestTemplate;
 @Service
 @RequiredArgsConstructor
 public class KakaoClient extends OAuthClient {
-    private final UserService userService;
     private final KakaoProperties kakaoProperties;
     private final ObjectMapper objectMapper;
 
@@ -83,24 +77,5 @@ public class KakaoClient extends OAuthClient {
         }catch (Exception e) {
             throw new CustomException(CommonErrorType.INTERNAL_SERVER_ERROR);
         }
-    }
-
-    @Override
-    @Transactional
-    public UserStatusDto getOAuthUser(String platformId) {
-        String platformUserId = OAuthPlatform.KAKAO + "_" + platformId;
-
-        return userService.readByUsername(platformUserId)
-                .map(user -> UserStatusDto.of(user, true))
-                .orElseGet(() -> new UserStatusDto(createOAuthUser(platformUserId), false));
-    }
-
-    private User createOAuthUser(String platformUserId) {
-        return userService.save(User.builder()
-                .username(platformUserId)
-                .nickname(platformUserId)
-                .platform(OAuthPlatform.KAKAO)
-                .build()
-        );
     }
 }

--- a/src/main/java/muzusi/application/auth/service/client/NaverClient.java
+++ b/src/main/java/muzusi/application/auth/service/client/NaverClient.java
@@ -3,11 +3,7 @@ package muzusi.application.auth.service.client;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import muzusi.application.auth.dto.UserStatusDto;
 import muzusi.application.auth.dto.UserInfoDto;
-import muzusi.domain.user.entity.User;
-import muzusi.domain.user.service.UserService;
-import muzusi.domain.user.type.OAuthPlatform;
 import muzusi.global.exception.CustomException;
 import muzusi.global.response.error.type.CommonErrorType;
 import muzusi.infrastructure.properties.NaverProperties;
@@ -17,7 +13,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
@@ -25,7 +20,6 @@ import org.springframework.web.client.RestTemplate;
 @Service
 @RequiredArgsConstructor
 public class NaverClient extends OAuthClient {
-    private final UserService userService;
     private final NaverProperties naverProperties;
     private final ObjectMapper objectMapper;
 
@@ -83,24 +77,5 @@ public class NaverClient extends OAuthClient {
         } catch (Exception e) {
             throw new CustomException(CommonErrorType.INTERNAL_SERVER_ERROR);
         }
-    }
-
-    @Override
-    @Transactional
-    public UserStatusDto getOAuthUser(String platformId) {
-        String platformUserId = OAuthPlatform.NAVER + "_" + platformId;
-
-        return userService.readByUsername(platformUserId)
-                .map(user -> UserStatusDto.of(user, true))
-                .orElseGet(() -> new UserStatusDto(createOAuthUser(platformUserId), false));
-    }
-
-    private User createOAuthUser(String platformUserId) {
-        return userService.save(User.builder()
-                .username(platformUserId)
-                .nickname(platformUserId)
-                .platform(OAuthPlatform.NAVER)
-                .build()
-        );
     }
 }

--- a/src/main/java/muzusi/application/auth/service/client/OAuthClient.java
+++ b/src/main/java/muzusi/application/auth/service/client/OAuthClient.java
@@ -1,6 +1,5 @@
 package muzusi.application.auth.service.client;
 
-import muzusi.application.auth.dto.UserStatusDto;
 import muzusi.application.auth.dto.UserInfoDto;
 
 public abstract class OAuthClient {
@@ -21,18 +20,8 @@ public abstract class OAuthClient {
      */
     public abstract UserInfoDto getUserInfo(String accessToken);
 
-    /**
-     * 플랫폼 id를 통해 로컬 서버 사용자 정보 불러오는 메서드
-     *
-     * @param platformId : 플랫폼의 id
-     * @return : 사용자 정보
-     */
-    public abstract UserStatusDto getOAuthUser(String platformId);
-
-    public UserStatusDto login(String code) {
+    public UserInfoDto fetchUserInfoFromPlatform(String code) {
         String accessToken = getAccessToken(code);
-        UserInfoDto userInfoDto = getUserInfo(accessToken);
-
-        return getOAuthUser(userInfoDto.id());
+        return getUserInfo(accessToken);
     }
 }

--- a/src/main/java/muzusi/domain/user/entity/User.java
+++ b/src/main/java/muzusi/domain/user/entity/User.java
@@ -52,4 +52,8 @@ public class User {
         this.nickname = nickname;
         this.platform = platform;
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/muzusi/domain/user/exception/UserErrorType.java
+++ b/src/main/java/muzusi/domain/user/exception/UserErrorType.java
@@ -11,7 +11,8 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorType implements BaseErrorType {
 
     UN_AUTHORIZED(HttpStatus.FORBIDDEN, "1005", "허용되지 않은 접근입니다."),
-    UNSUPPORTED_SOCIAL_LOGIN(HttpStatus.BAD_REQUEST, "1006", "지원하지 않는 소셜 로그인입니다.")
+    UNSUPPORTED_SOCIAL_LOGIN(HttpStatus.BAD_REQUEST, "1006", "지원하지 않는 소셜 로그인입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "1007", "존재하지 않는 사용자입니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/muzusi/domain/user/service/UserService.java
+++ b/src/main/java/muzusi/domain/user/service/UserService.java
@@ -23,5 +23,9 @@ public class UserService {
     public Optional<User> readByUsername(String username) {
         return userRepository.findByUsername(username);
     }
+
+    public void update(User user, String nickname) {
+        user.updateNickname(nickname);
+    }
 }
 

--- a/src/main/java/muzusi/presentation/auth/api/AuthApi.java
+++ b/src/main/java/muzusi/presentation/auth/api/AuthApi.java
@@ -10,8 +10,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import muzusi.application.auth.dto.OAuthCodeDto;
+import muzusi.application.auth.dto.SignUpDto;
 import muzusi.domain.user.type.OAuthPlatform;
+import muzusi.global.security.auth.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,6 +22,22 @@ import org.springframework.web.bind.annotation.RequestBody;
 @ApiGroup(value = "[인증 API]")
 @Tag(name = "[인증 API]", description = "인증 관련 API")
 public interface AuthApi {
+
+    @TrackApi(description = "회원가입")
+    @Operation(summary = "회원가입", description = "최초 로그인 시 회원 정보를 추가하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원가입 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> signUp(@AuthenticationPrincipal CustomUserDetails userDetails,
+                             @RequestBody SignUpDto signUpDto);
 
     @TrackApi(description = "소셜 로그인")
     @Operation(summary = "소셜 로그인", description = "서비스를 이용하기 위해 로그인하는 API입니다.")
@@ -72,6 +91,7 @@ public interface AuthApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                         {
+                                            "code": 200,
                                             "message": "요청이 성공하였습니다."
                                         }
                                     """)

--- a/src/main/java/muzusi/presentation/auth/controller/AuthController.java
+++ b/src/main/java/muzusi/presentation/auth/controller/AuthController.java
@@ -4,17 +4,20 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import muzusi.application.auth.dto.LoginDto;
 import muzusi.application.auth.dto.OAuthCodeDto;
+import muzusi.application.auth.dto.SignUpDto;
 import muzusi.application.auth.dto.TokenDto;
 import muzusi.application.auth.service.AuthService;
 import muzusi.domain.user.type.OAuthPlatform;
 import muzusi.global.exception.CustomException;
 import muzusi.global.response.error.type.CommonErrorType;
 import muzusi.global.response.success.SuccessResponse;
+import muzusi.global.security.auth.CustomUserDetails;
 import muzusi.global.util.cookie.CookieUtil;
 import muzusi.global.util.jwt.AuthConstants;
 import muzusi.presentation.auth.api.AuthApi;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -32,6 +35,13 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class AuthController implements AuthApi {
     private final AuthService authService;
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<?> signUp(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                    @RequestBody SignUpDto signUpDto) {
+        authService.signUp(userDetails.getUserId(), signUpDto);
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
 
     @Override
     @PostMapping("/sign-in/{platform}")

--- a/src/main/java/muzusi/presentation/auth/controller/AuthController.java
+++ b/src/main/java/muzusi/presentation/auth/controller/AuthController.java
@@ -36,6 +36,7 @@ import java.util.Map;
 public class AuthController implements AuthApi {
     private final AuthService authService;
 
+    @Override
     @PostMapping("/sign-up")
     public ResponseEntity<?> signUp(@AuthenticationPrincipal CustomUserDetails userDetails,
                                     @RequestBody SignUpDto signUpDto) {


### PR DESCRIPTION
## 배경
- close #17 
- 최초 로그인 시, 사용자 추가정보 입력

## 작업 사항
- OAuth 연결 로직 및 사용자 조회 로직 분리
- 회원 정보 추가 로직 구현 (회원가입)

## 추가 논의
OAuth관련 클래스에서 사용자의 정보를 찾고 없으면 새로 등록하는 메서드를 진행했는데, 단순히 통신만을 위해서 OAuth와 사용자 정보 불러오는 로직을 분리하였습니다!
그 과정에서 `signUp`과 `registerNewUser`의 의미가 헷갈리지 않나 라는 생각이 드는데
의견이 있으시다면 알려주시면 감사하겠습니다!