### PR TITLE
Fix: Replica Set 미적용에 따른 Transaction 설정 코드 삭제

### DIFF
--- a/src/main/java/muzusi/infrastructure/config/MongoConfig.java
+++ b/src/main/java/muzusi/infrastructure/config/MongoConfig.java
@@ -6,12 +6,9 @@ import lombok.RequiredArgsConstructor;
 import muzusi.infrastructure.properties.MongoProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
-@EnableTransactionManagement
 @RequiredArgsConstructor
 public class MongoConfig extends AbstractMongoClientConfiguration {
 
@@ -21,11 +18,6 @@ public class MongoConfig extends AbstractMongoClientConfiguration {
     @Bean
     public MongoClient mongoClient(){
         return MongoClients.create(mongoProperties.getConnectionUri());
-    }
-
-    @Bean
-    public MongoTransactionManager transactionManager(){
-        return new MongoTransactionManager(mongoDbFactory());
     }
 
     @Override


### PR DESCRIPTION
## 배경
- MongoDB Replica Set 미적용에 따른 Transaction 관련 설정 코드 삭제

## 작업 사항
- `MongoConfig` 내 Transaction 설정 코드 삭제