### PR TITLE
Feature: 한국투자증권 인증 API 연결

### DIFF
--- a/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
+++ b/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
@@ -1,0 +1,24 @@
+package muzusi.application.kis.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.kis.service.KisOAuthService;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@EnableScheduling
+public class KisScheduler {
+    private final KisOAuthService kisOAuthService;
+
+    @Scheduled(cron = "0 0 7 * * ?")
+    public void runIssueAccessTokenJob(){
+        kisOAuthService.saveAccessToken();
+    }
+
+    @Scheduled(cron = "0 0 0 1 1 ?")
+    public void runIssueWebSocketKeyJob(){
+        kisOAuthService.saveWebSocketKey();
+    }
+}

--- a/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
+++ b/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
@@ -13,12 +13,12 @@ public class KisScheduler {
     private final KisOAuthService kisOAuthService;
 
     @Scheduled(cron = "0 0 7 * * ?")
-    public void runIssueAccessTokenJob(){
+    public void runIssueAccessTokenJob() {
         kisOAuthService.saveAccessToken();
     }
 
     @Scheduled(cron = "0 0 0 1 1 ?")
-    public void runIssueWebSocketKeyJob(){
+    public void runIssueWebSocketKeyJob() {
         kisOAuthService.saveWebSocketKey();
     }
 }

--- a/src/main/java/muzusi/application/kis/service/KisOAuthService.java
+++ b/src/main/java/muzusi/application/kis/service/KisOAuthService.java
@@ -40,6 +40,6 @@ public class KisOAuthService {
         String webSocketKey = kisOAuthClient.getWebSocketKey();
 
         if(webSocketKey != null)
-            redisService.set(KisConstant.WEBSOCKET_KEY_PREFIX.getValue(), webSocketKey, Duration.ofDays(1));
+            redisService.set(KisConstant.WEBSOCKET_KEY_PREFIX.getValue(), webSocketKey, Duration.ofDays(365));
     }
 }

--- a/src/main/java/muzusi/application/kis/service/KisOAuthService.java
+++ b/src/main/java/muzusi/application/kis/service/KisOAuthService.java
@@ -20,6 +20,11 @@ public class KisOAuthService {
     public void issueWebSocketKey(){
         this.saveWebSocketKey();
     }
+
+    /**
+     * 한국투자증권 접근토큰 발급 API 호출 및 저장 메서드
+     * 접근토큰 발급 오류 발생 시, DB 데이터 갱신 미실시
+     */
     public void saveAccessToken(){
         String accessToken = kisOAuthClient.getAccessToken();
 
@@ -27,6 +32,10 @@ public class KisOAuthService {
             redisService.set(KisConstant.ACCESS_TOKEN_PREFIX.getValue(), accessToken, Duration.ofDays(1));
     }
 
+    /**
+     * 한국투자증권 웹소켓 접속키 발급 API 호출 및 저장 메서드
+     * 웹소켓 접속키 발급 오류 발생 시, DB 데이터 갱신 미실시
+     */
     public void saveWebSocketKey(){
         String webSocketKey = kisOAuthClient.getWebSocketKey();
 

--- a/src/main/java/muzusi/application/kis/service/KisOAuthService.java
+++ b/src/main/java/muzusi/application/kis/service/KisOAuthService.java
@@ -1,0 +1,36 @@
+package muzusi.application.kis.service;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import muzusi.global.redis.RedisService;
+import muzusi.infrastructure.kis.KisOAuthClient;
+import muzusi.infrastructure.kis.KisConstant;
+import org.springframework.stereotype.Service;
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KisOAuthService {
+    private final KisOAuthClient kisOAuthClient;
+    private final RedisService redisService;
+
+    @PostConstruct
+    public void issueWebSocketKey(){
+        this.saveWebSocketKey();
+    }
+    public void saveAccessToken(){
+        String accessToken = kisOAuthClient.getAccessToken();
+
+        if(accessToken != null)
+            redisService.set(KisConstant.ACCESS_TOKEN_PREFIX.getValue(), accessToken, Duration.ofDays(1));
+    }
+
+    public void saveWebSocketKey(){
+        String webSocketKey = kisOAuthClient.getWebSocketKey();
+
+        if(webSocketKey != null)
+            redisService.set(KisConstant.WEBSOCKET_KEY_PREFIX.getValue(), webSocketKey, Duration.ofDays(1));
+    }
+}

--- a/src/main/java/muzusi/application/kis/service/KisOAuthService.java
+++ b/src/main/java/muzusi/application/kis/service/KisOAuthService.java
@@ -17,7 +17,7 @@ public class KisOAuthService {
     private final RedisService redisService;
 
     @PostConstruct
-    public void issueWebSocketKey(){
+    public void issueWebSocketKey() {
         this.saveWebSocketKey();
     }
 
@@ -25,10 +25,10 @@ public class KisOAuthService {
      * 한국투자증권 접근토큰 발급 API 호출 및 저장 메서드
      * 접근토큰 발급 오류 발생 시, DB 데이터 갱신 미실시
      */
-    public void saveAccessToken(){
+    public void saveAccessToken() {
         String accessToken = kisOAuthClient.getAccessToken();
 
-        if(accessToken != null)
+        if (accessToken != null)
             redisService.set(KisConstant.ACCESS_TOKEN_PREFIX.getValue(), accessToken, Duration.ofDays(1));
     }
 
@@ -36,10 +36,10 @@ public class KisOAuthService {
      * 한국투자증권 웹소켓 접속키 발급 API 호출 및 저장 메서드
      * 웹소켓 접속키 발급 오류 발생 시, DB 데이터 갱신 미실시
      */
-    public void saveWebSocketKey(){
+    public void saveWebSocketKey() {
         String webSocketKey = kisOAuthClient.getWebSocketKey();
 
-        if(webSocketKey != null)
+        if (webSocketKey != null)
             redisService.set(KisConstant.WEBSOCKET_KEY_PREFIX.getValue(), webSocketKey, Duration.ofDays(365));
     }
 }

--- a/src/main/java/muzusi/global/redis/RedisService.java
+++ b/src/main/java/muzusi/global/redis/RedisService.java
@@ -11,6 +11,10 @@ import java.time.Duration;
 public class RedisService {
     private final RedisTemplate<String, Object> redisTemplate;
 
+    public Object get(String key){
+        return redisTemplate.opsForValue().get(key);
+    }
+
     public void set(String key, Object value, Duration duration) {
         redisTemplate.opsForValue().set(key, value, duration);
     }

--- a/src/main/java/muzusi/global/redis/RedisService.java
+++ b/src/main/java/muzusi/global/redis/RedisService.java
@@ -11,7 +11,7 @@ import java.time.Duration;
 public class RedisService {
     private final RedisTemplate<String, Object> redisTemplate;
 
-    public Object get(String key){
+    public Object get(String key) {
         return redisTemplate.opsForValue().get(key);
     }
 

--- a/src/main/java/muzusi/infrastructure/kis/KisConstant.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisConstant.java
@@ -1,0 +1,14 @@
+package muzusi.infrastructure.kis;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum KisConstant {
+    ACCESS_TOKEN_PREFIX("kis:access-token"),
+    WEBSOCKET_KEY_PREFIX("kis:websocket-key"),
+    ;
+
+    private final String value;
+}

--- a/src/main/java/muzusi/infrastructure/kis/KisOAuthClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisOAuthClient.java
@@ -57,7 +57,7 @@ public class KisOAuthClient {
      * 한국투자증권 웹소켓 접속키 발급 메서드
      * @return String : 한국투자증권 웹소켓 접속키
      */
-    public String getWebSocketKey(){
+    public String getWebSocketKey() {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
 

--- a/src/main/java/muzusi/infrastructure/kis/KisOAuthClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisOAuthClient.java
@@ -19,6 +19,10 @@ public class KisOAuthClient {
     private final KisProperties kisProperties;
     private final ObjectMapper objectMapper;
 
+    /**
+     * 한국투자증권 접근 토큰 발급 메서드
+     * @return String : 한국투자증권 API 접속토큰
+     */
     public String getAccessToken() {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -49,6 +53,10 @@ public class KisOAuthClient {
         }
     }
 
+    /**
+     * 한국투자증권 웹소켓 접속키 발급 메서드
+     * @return String : 한국투자증권 웹소켓 접속키
+     */
     public String getWebSocketKey(){
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);

--- a/src/main/java/muzusi/infrastructure/kis/KisOAuthClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisOAuthClient.java
@@ -1,0 +1,81 @@
+package muzusi.infrastructure.kis;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import muzusi.infrastructure.properties.KisProperties;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KisOAuthClient {
+    private final KisProperties kisProperties;
+    private final ObjectMapper objectMapper;
+
+    public String getAccessToken() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, String> body = new HashMap<>();
+        body.put("grant_type", "client_credentials");
+        body.put("appkey", kisProperties.getAppKey());
+        body.put("appsecret", kisProperties.getAppSecret());
+
+        HttpEntity<Map<String, String>> requestInfo = new HttpEntity<>(body, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        try{
+            ResponseEntity<String> response = restTemplate.exchange(
+                    kisProperties.getUrl(KisUrlConstant.ACCESS_TOKEN_ISSUE),
+                    HttpMethod.POST,
+                    requestInfo,
+                    String.class
+            );
+
+            JsonNode rootNode = objectMapper.readTree(response.getBody());
+
+            return rootNode.path("token_type").asText() + " "  + rootNode.path("access_token").asText();
+        } catch (Exception e){
+            log.error("[KIS ERROR] " + e.getMessage());
+            return null;
+        }
+    }
+
+    public String getWebSocketKey(){
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, String> body = new HashMap<>();
+        body.put("grant_type", "client_credentials");
+        body.put("appkey", kisProperties.getAppKey());
+        body.put("secretkey", kisProperties.getAppSecret());
+
+        HttpEntity<Map<String, String>> requestInfo = new HttpEntity<>(body, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        try{
+            ResponseEntity<String> response = restTemplate.exchange(
+                    kisProperties.getUrl(KisUrlConstant.WEBSOCKET_KEY_ISSUE),
+                    HttpMethod.POST,
+                    requestInfo,
+                    String.class
+            );
+
+            JsonNode rootNode = objectMapper.readTree(response.getBody());
+
+            return rootNode.path("approval_key").asText();
+        } catch (Exception e){
+            log.error("[KIS ERROR] " + e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/muzusi/infrastructure/kis/KisUrlConstant.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisUrlConstant.java
@@ -1,0 +1,14 @@
+package muzusi.infrastructure.kis;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum KisUrlConstant {
+    ACCESS_TOKEN_ISSUE("/oauth2/tokenP"),
+    WEBSOCKET_KEY_ISSUE("/oauth2/Approval"),
+    ;
+
+    private final String url;
+}

--- a/src/main/java/muzusi/infrastructure/properties/KisProperties.java
+++ b/src/main/java/muzusi/infrastructure/properties/KisProperties.java
@@ -1,0 +1,20 @@
+package muzusi.infrastructure.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import muzusi.infrastructure.kis.KisUrlConstant;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "kis")
+@Getter @Setter
+public class KisProperties {
+    private String domain;
+    private String appKey;
+    private String appSecret;
+
+    public String getUrl(KisUrlConstant kisUrlConstant){
+        return domain + kisUrlConstant.getUrl();
+    }
+}

--- a/src/main/java/muzusi/infrastructure/properties/KisProperties.java
+++ b/src/main/java/muzusi/infrastructure/properties/KisProperties.java
@@ -14,7 +14,7 @@ public class KisProperties {
     private String appKey;
     private String appSecret;
 
-    public String getUrl(KisUrlConstant kisUrlConstant){
+    public String getUrl(KisUrlConstant kisUrlConstant) {
         return domain + kisUrlConstant.getUrl();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,3 +63,8 @@ news:
   clientId: ${NEWS_CLIENT_ID}
   clientSecret: ${NEWS_CLIENT_SECRET}
   newsApiUrl: ${NEWS_API_URL}
+
+kis:
+  domain: ${KIS_DOMAIN:https://openapi.koreainvestment.com:9443}
+  appkey: ${KIS_APPKEY:appkey}
+  appsecret: ${KIS_APPSECRET:appsecret}


### PR DESCRIPTION
## 배경
- #31 

## 작업 사항
- 한국투자증권 접근토큰 발급 및 Redis 내 저장
   - 스케쥴링 적용(매일 7시)
- 한국투자증권 웹소켓 접속키 발급 및 Redis 내 저장
   - 스케쥴링 적용(매년 1월 1일) / 애플리케이션 시작 시
- `RedisService` 내 조회 메서드 `get(String key)` 추가

## 추가 논의
- 코드 리뷰 후, 배포 서버 환경변수 수정하도록 하겠습니다.
- `@EnableScheduling` 어노테이션 설정 클래스 분리 필요
