### PR TITLE
Feature: 뉴스 삭제 스케쥴러 구현

### DIFF
--- a/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
+++ b/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
@@ -2,13 +2,11 @@ package muzusi.application.kis.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import muzusi.application.kis.service.KisOAuthService;
-import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-@EnableScheduling
 public class KisScheduler {
     private final KisOAuthService kisOAuthService;
 

--- a/src/main/java/muzusi/application/news/scheduler/NewsScheduler.java
+++ b/src/main/java/muzusi/application/news/scheduler/NewsScheduler.java
@@ -2,12 +2,10 @@ package muzusi.application.news.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import muzusi.application.news.service.NewsManagementService;
-import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
-@EnableScheduling
 @RequiredArgsConstructor
 public class NewsScheduler {
     private final NewsManagementService newsManagementService;

--- a/src/main/java/muzusi/application/news/scheduler/NewsScheduler.java
+++ b/src/main/java/muzusi/application/news/scheduler/NewsScheduler.java
@@ -13,7 +13,12 @@ public class NewsScheduler {
     private final NewsManagementService newsManagementService;
 
     @Scheduled(cron = "0 */10 7-22 * * *")
-    public void runDailyNewsProcessJob() {
+    public void runNewsSyncJob() {
         newsManagementService.createPostsFromNews();
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void runNewsDeleteJob() {
+        newsManagementService.deleteNews();
     }
 }

--- a/src/main/java/muzusi/application/news/service/NewsManagementService.java
+++ b/src/main/java/muzusi/application/news/service/NewsManagementService.java
@@ -8,6 +8,7 @@ import muzusi.infrastructure.news.NewsApiClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -37,5 +38,16 @@ public class NewsManagementService {
                         )
                         .forEach(newsService::save)
         );
+    }
+
+    /**
+     * 오래된 뉴스를 삭제하는 메서드.
+     * 2일이 지난 뉴스들을 삭제한다.
+     */
+    @Transactional
+    public void deleteNews() {
+        LocalDateTime twoDaysAgo = LocalDateTime.now().minusDays(2);
+        List<Long> newsIds = newsService.readIdsByDate(twoDaysAgo);
+        newsService.deleteIds(newsIds);
     }
 }

--- a/src/main/java/muzusi/application/news/service/NewsManagementService.java
+++ b/src/main/java/muzusi/application/news/service/NewsManagementService.java
@@ -48,6 +48,6 @@ public class NewsManagementService {
     public void deleteNews() {
         LocalDateTime twoDaysAgo = LocalDateTime.now().minusDays(2);
         List<Long> newsIds = newsService.readIdsByDate(twoDaysAgo);
-        newsService.deleteIds(newsIds);
+        newsService.deleteByIds(newsIds);
     }
 }

--- a/src/main/java/muzusi/domain/news/repository/NewsRepository.java
+++ b/src/main/java/muzusi/domain/news/repository/NewsRepository.java
@@ -4,8 +4,21 @@ import muzusi.domain.news.entity.News;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface NewsRepository extends JpaRepository<News, Long> {
     Page<News> findByKeyword(String keyword, Pageable pageable);
     boolean existsByTitle(String title);
+
+    @Query("SELECT n.id FROM news n WHERE n.pubDate < :dateTime")
+    List<Long> findIdsByPubDateBefore(@Param("dateTime") LocalDateTime dateTime);
+
+    @Modifying
+    @Query("DELETE FROM news n WHERE n.id IN :ids")
+    void deleteByIds(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/muzusi/domain/news/service/NewsService.java
+++ b/src/main/java/muzusi/domain/news/service/NewsService.java
@@ -35,7 +35,7 @@ public class NewsService {
         return newsRepository.existsByTitle(title);
     }
 
-    public void deleteIds(List<Long> ids) {
+    public void deleteByIds(List<Long> ids) {
         newsRepository.deleteByIds(ids);
     }
 }

--- a/src/main/java/muzusi/domain/news/service/NewsService.java
+++ b/src/main/java/muzusi/domain/news/service/NewsService.java
@@ -7,6 +7,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class NewsService {
@@ -24,7 +27,15 @@ public class NewsService {
         return newsRepository.findByKeyword(keyword, pageable);
     }
 
+    public List<Long> readIdsByDate(LocalDateTime dateTime) {
+        return newsRepository.findIdsByPubDateBefore(dateTime);
+    }
+
     public boolean existsByTitle(String title) {
         return newsRepository.existsByTitle(title);
+    }
+
+    public void deleteIds(List<Long> ids) {
+        newsRepository.deleteByIds(ids);
     }
 }

--- a/src/main/java/muzusi/infrastructure/config/SchedulingConfig.java
+++ b/src/main/java/muzusi/infrastructure/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package muzusi.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}


### PR DESCRIPTION
## 배경
- close #29 
- DB에 저장된 오래된 뉴스 삭제 스케쥴러 등록

## 작업 사항
- 날짜 기준 뉴스 검색 및 삭제 로직 구현
- 스케쥴러 등록 (매일 자정에 실시)

## 추가 논의
 - 일단 이틀을 기준으로 이틀이 지난 뉴스를 삭제하고 있습니다. (전 날의 뉴스 또한 다음 날에 영향를 끼칠 수 있으니)
 아니면, 생각하시는 일자에 대해서 말씀해주세요!
 - JPA 네이밍 메서드 중 `deleteAllByIdInBatch`라는 메서드가 있습니다! 이것 이 제가 현재 (2a001073ff3974591e553af8774292cef2b5bed9)에서 작성한 `deleteByIds`과 똑같은 기능을 하지만, 익숙하지 않은 네이밍 메서드라 좀 더 이해하기 쉬울 수 있도록 JPQL을 직접 작성한 것입니다!

## 테스트
스케쥴러로 일정 시간이 지난 뉴스의 id값을 통해 한번에 삭제하는 쿼지를 날리는 스크린샷입니다.
<img width="716" alt="image" src="https://github.com/user-attachments/assets/79472d49-dc02-4fcc-bb8c-61d5255f6062" />
