### PR TITLE
Feature: 계좌 생성 로직 구현

### DIFF
--- a/src/main/java/muzusi/application/account/service/AccountManagementService.java
+++ b/src/main/java/muzusi/application/account/service/AccountManagementService.java
@@ -1,0 +1,29 @@
+package muzusi.application.account.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.account.entity.Account;
+import muzusi.domain.account.service.AccountService;
+import muzusi.domain.user.entity.User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccountManagementService {
+    private final AccountService accountService;
+
+    private static final Long DEFAULT_BALANCE = 10_000_000L;
+
+    /**
+     * 새로운 계좌 연결하는 메서드.
+     *
+     * @param user : 사용자 정보
+     */
+    public void createAndLinkAccount(User user) {
+        Account account = Account.builder()
+                .user(user)
+                .balance(DEFAULT_BALANCE)
+                .build();
+
+        accountService.save(account);
+    }
+}

--- a/src/main/java/muzusi/application/account/service/UserAccountService.java
+++ b/src/main/java/muzusi/application/account/service/UserAccountService.java
@@ -1,0 +1,29 @@
+package muzusi.application.account.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.user.entity.User;
+import muzusi.domain.user.exception.UserErrorType;
+import muzusi.domain.user.service.UserService;
+import muzusi.global.exception.CustomException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserAccountService {
+    private final UserService userService;
+    private final AccountManagementService accountManagementService;
+
+    /**
+     * 새로운 계좌를 등록하기 위한 메서드.
+     *
+     * @param userId : 사용자의 pk값
+     */
+    @Transactional
+    public void connectNewAccount(Long userId) {
+        User foundUser = userService.readById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
+
+        accountManagementService.createAndLinkAccount(foundUser);
+    }
+}

--- a/src/main/java/muzusi/application/account/service/UserAccountService.java
+++ b/src/main/java/muzusi/application/account/service/UserAccountService.java
@@ -24,6 +24,7 @@ public class UserAccountService {
         User foundUser = userService.readById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
 
+        foundUser.incrementAttemptCount();
         accountManagementService.createAndLinkAccount(foundUser);
     }
 }

--- a/src/main/java/muzusi/application/auth/service/AuthService.java
+++ b/src/main/java/muzusi/application/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package muzusi.application.auth.service;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import muzusi.application.account.service.AccountManagementService;
 import muzusi.application.auth.dto.LoginDto;
 import muzusi.application.auth.dto.SignUpDto;
 import muzusi.application.auth.dto.TokenDto;
@@ -23,6 +24,7 @@ public class AuthService {
     private final OAuthClientFactory oAuthClientFactory;
     private final JwtHelper jwtHelper;
     private final UserService userService;
+    private final AccountManagementService accountManagementService;
 
     /**
      * 서비스 로그인을 위한 메서드
@@ -72,6 +74,9 @@ public class AuthService {
                         .platform(platform)
                         .build()
         );
+
+        accountManagementService.createAndLinkAccount(newUser);
+
         return UserStatusDto.of(newUser, false);
     }
 

--- a/src/main/java/muzusi/domain/account/repository/AccountRepository.java
+++ b/src/main/java/muzusi/domain/account/repository/AccountRepository.java
@@ -1,0 +1,7 @@
+package muzusi.domain.account.repository;
+
+import muzusi.domain.account.entity.Account;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+}

--- a/src/main/java/muzusi/domain/account/service/AccountService.java
+++ b/src/main/java/muzusi/domain/account/service/AccountService.java
@@ -1,0 +1,16 @@
+package muzusi.domain.account.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.account.entity.Account;
+import muzusi.domain.account.repository.AccountRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+    private final AccountRepository accountRepository;
+
+    public void save(Account account) {
+        accountRepository.save(account);
+    }
+}

--- a/src/main/java/muzusi/domain/user/entity/User.java
+++ b/src/main/java/muzusi/domain/user/entity/User.java
@@ -37,7 +37,7 @@ public class User {
     private String nickname;
 
     @Column(name = "attempt_count")
-    private int attemptCount;
+    private Integer attemptCount;
 
     @ColumnDefault("NULL")
     @Column(name = "deleted_at")
@@ -50,10 +50,15 @@ public class User {
     public User(String username, String nickname, OAuthPlatform platform) {
         this.username = username;
         this.nickname = nickname;
+        this.attemptCount = 1;
         this.platform = platform;
     }
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void incrementAttemptCount() {
+        this.attemptCount++;
     }
 }

--- a/src/main/java/muzusi/global/response/success/SuccessResponse.java
+++ b/src/main/java/muzusi/global/response/success/SuccessResponse.java
@@ -1,10 +1,12 @@
 package muzusi.global.response.success;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import muzusi.global.response.success.type.SuccessType;
 import org.springframework.http.HttpStatus;
 
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record SuccessResponse<T>(
         int code,
         String message,

--- a/src/main/java/muzusi/presentation/account/api/AccountApi.java
+++ b/src/main/java/muzusi/presentation/account/api/AccountApi.java
@@ -1,0 +1,33 @@
+package muzusi.presentation.account.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import muzusi.global.security.auth.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@ApiGroup(value = "[계좌 API]")
+@Tag(name = "[계좌 API]", description = "계좌 관련 API")
+public interface AccountApi {
+
+    @TrackApi(description = "계좌 생성")
+    @Operation(summary = "계좌 생성", description = "시드 재생성을 위한 계좌 생성하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "계좌생성 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> createNewAccount(@AuthenticationPrincipal CustomUserDetails userDetails);
+}

--- a/src/main/java/muzusi/presentation/account/controller/AccountController.java
+++ b/src/main/java/muzusi/presentation/account/controller/AccountController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import muzusi.application.account.service.UserAccountService;
 import muzusi.global.response.success.SuccessResponse;
 import muzusi.global.security.auth.CustomUserDetails;
+import muzusi.presentation.account.api.AccountApi;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,9 +14,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/accounts")
 @RequiredArgsConstructor
-public class AccountController {
+public class AccountController implements AccountApi {
     private final UserAccountService userAccountService;
 
+    @Override
     @PostMapping
     public ResponseEntity<?> createNewAccount(@AuthenticationPrincipal CustomUserDetails userDetails) {
         userAccountService.connectNewAccount(userDetails.getUserId());

--- a/src/main/java/muzusi/presentation/account/controller/AccountController.java
+++ b/src/main/java/muzusi/presentation/account/controller/AccountController.java
@@ -1,0 +1,25 @@
+package muzusi.presentation.account.controller;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.account.service.UserAccountService;
+import muzusi.global.response.success.SuccessResponse;
+import muzusi.global.security.auth.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/accounts")
+@RequiredArgsConstructor
+public class AccountController {
+    private final UserAccountService userAccountService;
+
+    @PostMapping
+    public ResponseEntity<?> createNewAccount(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        userAccountService.connectNewAccount(userDetails.getUserId());
+
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+}


### PR DESCRIPTION
## 배경
- #40 

## 작업 사항
- 계좌 생성 로직 구현
- 최초 계정 생성 시, 계좌 연결 및 계좌 생성횟수 1로 초기화
- `SuccessResponse`에서 `null`인 데이터 반환 처리

## 추가 논의
- 계좌 시드 부활에 대해 횟수를 제한할 것인지 의견을 묻고 싶습니다!
- `SuccessResponse.ok()`를 할 시, data가 null로 반환되는 문제를 처리했습니다.