### PR TITLE
Feature: 계좌 전체 불러오기 및 최신 계좌 불러오기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-	implementation 'io.github.daeyoung0726:api-link-checker:0.0.6'
+	implementation 'io.github.daeyoung0726:api-link-checker:0.1.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/muzusi/application/account/dto/AccountInfoDto.java
+++ b/src/main/java/muzusi/application/account/dto/AccountInfoDto.java
@@ -1,0 +1,13 @@
+package muzusi.application.account.dto;
+
+import muzusi.domain.account.entity.Account;
+
+public record AccountInfoDto(
+        Long id,
+        Long balance,
+        double rateOfReturn
+) {
+    public static AccountInfoDto fromEntity(Account account) {
+        return new AccountInfoDto(account.getId(), account.getBalance(), account.getRateOfReturn());
+    }
+}

--- a/src/main/java/muzusi/application/account/service/UserAccountService.java
+++ b/src/main/java/muzusi/application/account/service/UserAccountService.java
@@ -2,6 +2,7 @@ package muzusi.application.account.service;
 
 import lombok.RequiredArgsConstructor;
 import muzusi.application.account.dto.AccountInfoDto;
+import muzusi.domain.account.exception.AccountErrorType;
 import muzusi.domain.account.service.AccountService;
 import muzusi.domain.user.entity.User;
 import muzusi.domain.user.exception.UserErrorType;
@@ -44,5 +45,19 @@ public class UserAccountService {
         return accountService.readAllByUserId(userId)
                 .stream().map(AccountInfoDto::fromEntity)
                 .toList();
+    }
+
+    /**
+     * 사용자의 현재 계좌 (최신계좌) 불러오는 메서드
+     *
+     * @param userId : 사용자의 pk값
+     * @return : 사용자의 현재 계좌 정보
+     */
+    @Transactional(readOnly = true)
+    public AccountInfoDto getAccount(Long userId) {
+        return AccountInfoDto.fromEntity(
+                accountService.readByUserId(userId)
+                        .orElseThrow(() -> new CustomException(AccountErrorType.NOT_FOUND))
+        );
     }
 }

--- a/src/main/java/muzusi/application/account/service/UserAccountService.java
+++ b/src/main/java/muzusi/application/account/service/UserAccountService.java
@@ -1,6 +1,8 @@
 package muzusi.application.account.service;
 
 import lombok.RequiredArgsConstructor;
+import muzusi.application.account.dto.AccountInfoDto;
+import muzusi.domain.account.service.AccountService;
 import muzusi.domain.user.entity.User;
 import muzusi.domain.user.exception.UserErrorType;
 import muzusi.domain.user.service.UserService;
@@ -8,10 +10,13 @@ import muzusi.global.exception.CustomException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class UserAccountService {
     private final UserService userService;
+    private final AccountService accountService;
     private final AccountManagementService accountManagementService;
 
     /**
@@ -26,5 +31,18 @@ public class UserAccountService {
 
         foundUser.incrementAttemptCount();
         accountManagementService.createAndLinkAccount(foundUser);
+    }
+
+    /**
+     * 사용자의 계좌들을 불러오는 메서드
+     *
+     * @param userId : 사용자의 pk값
+     * @return : 사용자의 계좌 정보 list
+     */
+    @Transactional(readOnly = true)
+    public List<AccountInfoDto> getAllAccounts(Long userId) {
+        return accountService.readAllByUserId(userId)
+                .stream().map(AccountInfoDto::fromEntity)
+                .toList();
     }
 }

--- a/src/main/java/muzusi/domain/account/entity/Account.java
+++ b/src/main/java/muzusi/domain/account/entity/Account.java
@@ -2,6 +2,7 @@ package muzusi.domain.account.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -13,9 +14,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import muzusi.domain.user.entity.User;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 @Entity(name = "account")
 public class Account {
     @Id
@@ -26,6 +32,10 @@ public class Account {
 
     @Column(name = "rate_of_return")
     private double rateOfReturn;
+
+    @Column(name = "created_at")
+    @CreatedDate
+    private LocalDateTime createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/muzusi/domain/account/exception/AccountErrorType.java
+++ b/src/main/java/muzusi/domain/account/exception/AccountErrorType.java
@@ -1,0 +1,33 @@
+package muzusi.domain.account.exception;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.global.response.error.type.BaseErrorType;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Account ErrorCode: 4xxx
+ */
+@RequiredArgsConstructor
+public enum AccountErrorType implements BaseErrorType {
+    NOT_FOUND(HttpStatus.NOT_FOUND, "4001", "계좌가 존재하지 않습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/muzusi/domain/account/repository/AccountRepository.java
+++ b/src/main/java/muzusi/domain/account/repository/AccountRepository.java
@@ -3,5 +3,8 @@ package muzusi.domain.account.repository;
 import muzusi.domain.account.entity.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AccountRepository extends JpaRepository<Account, Long> {
+    List<Account> findByUser_Id(Long userId);
 }

--- a/src/main/java/muzusi/domain/account/repository/AccountRepository.java
+++ b/src/main/java/muzusi/domain/account/repository/AccountRepository.java
@@ -2,9 +2,15 @@ package muzusi.domain.account.repository;
 
 import muzusi.domain.account.entity.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
     List<Account> findByUser_Id(Long userId);
+
+    @Query(value = "SELECT * FROM account a WHERE a.user_id = :userId ORDER BY a.created_at DESC LIMIT 1", nativeQuery = true)
+    Optional<Account> findLatestAccount(@Param("userId") Long userId);
 }

--- a/src/main/java/muzusi/domain/account/service/AccountService.java
+++ b/src/main/java/muzusi/domain/account/service/AccountService.java
@@ -5,6 +5,8 @@ import muzusi.domain.account.entity.Account;
 import muzusi.domain.account.repository.AccountRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class AccountService {
@@ -12,5 +14,9 @@ public class AccountService {
 
     public void save(Account account) {
         accountRepository.save(account);
+    }
+
+    public List<Account> readAllByUserId(Long userId) {
+        return accountRepository.findByUser_Id(userId);
     }
 }

--- a/src/main/java/muzusi/domain/account/service/AccountService.java
+++ b/src/main/java/muzusi/domain/account/service/AccountService.java
@@ -6,6 +6,7 @@ import muzusi.domain.account.repository.AccountRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,5 +19,9 @@ public class AccountService {
 
     public List<Account> readAllByUserId(Long userId) {
         return accountRepository.findByUser_Id(userId);
+    }
+
+    public Optional<Account> readByUserId(Long userId) {
+        return accountRepository.findLatestAccount(userId);
     }
 }

--- a/src/main/java/muzusi/presentation/account/api/AccountApi.java
+++ b/src/main/java/muzusi/presentation/account/api/AccountApi.java
@@ -30,4 +30,59 @@ public interface AccountApi {
                     }))
     })
     ResponseEntity<?> createNewAccount(@AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @TrackApi(description = "사용자 전체 계좌 불러오기")
+    @Operation(summary = "사용자 전체 계좌 불러오기", description = "사용자 전체 계좌를 불러오는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "계좌 불러오기 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                "content": [
+                                                    {
+                                                        "id": 1,
+                                                        "balance": 10000000,
+                                                        "rateOfReturn": 0.0
+                                                    },
+                                                    {
+                                                        "id": 2,
+                                                        "balance": 20000000,
+                                                        "rateOfReturn": 100.0
+                                                    }
+                                                ],
+                                                "page": {
+                                                    "size": 10,
+                                                    "number": 0,
+                                                    "totalElements": 2,
+                                                    "totalPages": 1
+                                                }
+                                            }
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getAllAccounts(@AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @TrackApi(description = "사용자 최신 계좌 불러오기")
+    @Operation(summary = "사용자 최신 계좌 불러오기", description = "사용자 최신 계좌를 불러오는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "계좌 불러오기 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                "id": 2,
+                                                "balance": 20000000,
+                                                "rateOfReturn": 100.0
+                                            }
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getAccount(@AuthenticationPrincipal CustomUserDetails userDetails);
 }

--- a/src/main/java/muzusi/presentation/account/controller/AccountController.java
+++ b/src/main/java/muzusi/presentation/account/controller/AccountController.java
@@ -26,6 +26,7 @@ public class AccountController implements AccountApi {
         return ResponseEntity.ok(SuccessResponse.ok());
     }
 
+    @Override
     @GetMapping
     public ResponseEntity<?> getAllAccounts(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok(
@@ -33,6 +34,7 @@ public class AccountController implements AccountApi {
         );
     }
 
+    @Override
     @GetMapping("/current")
     public ResponseEntity<?> getAccount(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok(

--- a/src/main/java/muzusi/presentation/account/controller/AccountController.java
+++ b/src/main/java/muzusi/presentation/account/controller/AccountController.java
@@ -7,6 +7,7 @@ import muzusi.global.security.auth.CustomUserDetails;
 import muzusi.presentation.account.api.AccountApi;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,5 +24,12 @@ public class AccountController implements AccountApi {
         userAccountService.connectNewAccount(userDetails.getUserId());
 
         return ResponseEntity.ok(SuccessResponse.ok());
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getAllAccounts(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(userAccountService.getAllAccounts(userDetails.getUserId()))
+        );
     }
 }

--- a/src/main/java/muzusi/presentation/account/controller/AccountController.java
+++ b/src/main/java/muzusi/presentation/account/controller/AccountController.java
@@ -32,4 +32,11 @@ public class AccountController implements AccountApi {
                 SuccessResponse.from(userAccountService.getAllAccounts(userDetails.getUserId()))
         );
     }
+
+    @GetMapping("/current")
+    public ResponseEntity<?> getAccount(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(userAccountService.getAccount(userDetails.getUserId()))
+        );
+    }
 }


### PR DESCRIPTION
## 배경
- close #40 

## 작업 사항
- 사용자의 전쳬 계좌 불러오기
- 사용자의 최신 계좌 (현재 계좌) 불러오기

## 추가 논의
 - 최신 계좌를 불러오는 과정에서 `네이티브 쿼리`를 사용한 이유는 값을 찾으면 바로 해당 값만 불러오는 `LIMIT`를 사용하기 위해서 사용하였습니다.

## 테스트
- 전체 계좌 불러오기
<img width="519" alt="스크린샷 2025-01-13 오전 12 49 20" src="https://github.com/user-attachments/assets/31dba687-0784-4cc6-bfa9-6d924030d82f" />

- 최신 계좌 불러오기
<img width="482" alt="스크린샷 2025-01-13 오전 12 49 26" src="https://github.com/user-attachments/assets/44964037-3c6c-4420-a92c-db846cf8a13e" />


