### PR TITLE
Feature: 주식 매수/매도 로직 구현

### DIFF
--- a/src/main/java/muzusi/application/stock/service/StockService.java
+++ b/src/main/java/muzusi/application/stock/service/StockService.java
@@ -15,4 +15,8 @@ public class StockService {
     public Optional<Stock> readByStockName(String stockName) {
         return stockRepository.findByStockName(stockName);
     }
+
+    public Optional<Stock> readByStockCode(String stockCode) {
+        return stockRepository.findByStockCode(stockCode);
+    }
 }

--- a/src/main/java/muzusi/application/trade/dto/TradeReqDto.java
+++ b/src/main/java/muzusi/application/trade/dto/TradeReqDto.java
@@ -1,0 +1,17 @@
+package muzusi.application.trade.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import muzusi.domain.trade.type.TradeType;
+
+public record TradeReqDto(
+        @NotNull(message = "주식 가격은 필수 입력입니다.")
+        Long stockPrice,
+        @NotNull(message = "주식 개수는 필수 입력입니다.")
+        Integer stockCount,
+        @NotBlank(message = "주식 코드는 필수 정보입니다.")
+        String stockCode,
+        @NotNull(message = "매수/매도는 필수 선택입니다.")
+        TradeType tradeType
+) {
+}

--- a/src/main/java/muzusi/application/trade/dto/TradeReqDto.java
+++ b/src/main/java/muzusi/application/trade/dto/TradeReqDto.java
@@ -1,16 +1,25 @@
 package muzusi.application.trade.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import muzusi.domain.trade.type.TradeType;
 
+@Schema(name = "TradeReqDto", description = "주식 매수/매도를 위한 DTO")
 public record TradeReqDto(
+        @Schema(description = "사용자가 입력한 가격", example = "3000")
         @NotNull(message = "주식 가격은 필수 입력입니다.")
         Long stockPrice,
+
+        @Schema(description = "사용자가 입력한 매수/매도 개수", example = "3")
         @NotNull(message = "주식 개수는 필수 입력입니다.")
         Integer stockCount,
+
+        @Schema(description = "주식 코드", example = "000610")
         @NotBlank(message = "주식 코드는 필수 정보입니다.")
         String stockCode,
+
+        @Schema(description = "매수/매도 타입", example = "BUY or SELL")
         @NotNull(message = "매수/매도는 필수 선택입니다.")
         TradeType tradeType
 ) {

--- a/src/main/java/muzusi/application/trade/service/StockTradeService.java
+++ b/src/main/java/muzusi/application/trade/service/StockTradeService.java
@@ -1,0 +1,48 @@
+package muzusi.application.trade.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.stock.service.StockService;
+import muzusi.application.trade.dto.TradeReqDto;
+import muzusi.domain.account.entity.Account;
+import muzusi.domain.account.exception.AccountErrorType;
+import muzusi.domain.account.service.AccountService;
+import muzusi.domain.stock.entity.Stock;
+import muzusi.domain.stock.exception.StockErrorType;
+import muzusi.domain.trade.entity.Trade;
+import muzusi.domain.trade.service.TradeService;
+import muzusi.global.exception.CustomException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StockTradeService {
+    private final TradeService tradeService;
+    private final StockService stockService;
+    private final AccountService accountService;
+
+    /**
+     * 주식 매수, 매도 메서드
+     *
+     * @param userId : 사용자 pk값
+     * @param tradeReqDto : trade 정보 dto
+     */
+    @Transactional
+    public void tradeStock(Long userId, TradeReqDto tradeReqDto) {
+        Account account = accountService.readByUserId(userId)
+                .orElseThrow(() -> new CustomException(AccountErrorType.NOT_FOUND));
+
+        Stock stock = stockService.readByStockCode(tradeReqDto.stockCode())
+                .orElseThrow(() -> new CustomException(StockErrorType.NOT_FOUND));
+
+        tradeService.save(
+                Trade.builder()
+                        .stockPrice(tradeReqDto.stockPrice())
+                        .stockCount(tradeReqDto.stockCount())
+                        .tradeType(tradeReqDto.tradeType())
+                        .stock(stock)
+                        .account(account)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/muzusi/domain/stock/exception/StockErrorType.java
+++ b/src/main/java/muzusi/domain/stock/exception/StockErrorType.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
  */
 @RequiredArgsConstructor
 public enum StockErrorType implements BaseErrorType {
+    NOT_FOUND(HttpStatus.NOT_FOUND, "2001", "주식 종목이 존재하지 않습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/muzusi/domain/stock/repository/StockRepository.java
+++ b/src/main/java/muzusi/domain/stock/repository/StockRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface StockRepository extends JpaRepository<Stock, Long> {
     Optional<Stock> findByStockName(String stockName);
+    Optional<Stock> findByStockCode(String stockCode);
 }

--- a/src/main/java/muzusi/domain/trade/entity/Trade.java
+++ b/src/main/java/muzusi/domain/trade/entity/Trade.java
@@ -36,7 +36,7 @@ public class Trade {
     private Long stockPrice;
 
     @Column(name = "stock_count")
-    private int stockCount;
+    private Integer stockCount;
 
     @Column(name = "trade_at")
     @CreatedDate
@@ -54,7 +54,7 @@ public class Trade {
     private Account account;
 
     @Builder
-    public Trade(Long stockPrice, int stockCount, TradeType tradeType, Stock stock, Account account) {
+    public Trade(Long stockPrice, Integer stockCount, TradeType tradeType, Stock stock, Account account) {
         this.stockPrice = stockPrice;
         this.stockCount = stockCount;
         this.tradeType = tradeType;

--- a/src/main/java/muzusi/domain/trade/entity/Trade.java
+++ b/src/main/java/muzusi/domain/trade/entity/Trade.java
@@ -17,6 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import muzusi.domain.account.entity.Account;
 import muzusi.domain.stock.entity.Stock;
+import muzusi.domain.trade.type.TradeType;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 

--- a/src/main/java/muzusi/domain/trade/repository/TradeRepository.java
+++ b/src/main/java/muzusi/domain/trade/repository/TradeRepository.java
@@ -1,0 +1,7 @@
+package muzusi.domain.trade.repository;
+
+import muzusi.domain.trade.entity.Trade;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TradeRepository extends JpaRepository<Trade, Long> {
+}

--- a/src/main/java/muzusi/domain/trade/service/TradeService.java
+++ b/src/main/java/muzusi/domain/trade/service/TradeService.java
@@ -1,0 +1,16 @@
+package muzusi.domain.trade.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.trade.entity.Trade;
+import muzusi.domain.trade.repository.TradeRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TradeService {
+    private final TradeRepository tradeRepository;
+
+    public void save(Trade trade) {
+        tradeRepository.save(trade);
+    }
+}

--- a/src/main/java/muzusi/domain/trade/type/TradeType.java
+++ b/src/main/java/muzusi/domain/trade/type/TradeType.java
@@ -1,4 +1,4 @@
-package muzusi.domain.trade.entity;
+package muzusi.domain.trade.type;
 
 public enum TradeType {
     BUY, SELL

--- a/src/main/java/muzusi/presentation/trade/api/TradeApi.java
+++ b/src/main/java/muzusi/presentation/trade/api/TradeApi.java
@@ -1,0 +1,63 @@
+package muzusi.presentation.trade.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import muzusi.application.trade.dto.TradeReqDto;
+import muzusi.global.security.auth.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@ApiGroup(value = "[거래 API]")
+@Tag(name = "[거래 API]", description = "거래 관련 API")
+public interface TradeApi {
+
+    @TrackApi(description = "주식 거래")
+    @Operation(summary = "주식 거래", description = "주식 매수/매도를 위한 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주식 거래 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "주식 존재 x ",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "NotFoundStock", value = """
+                                        {
+                                            "code": "2001",
+                                            "message": "주식 종목이 존재하지 않습니다."
+                                        }
+                                    """),
+                            @ExampleObject(name = "NotFoundAccount", value = """
+                                        {
+                                            "code": "4001",
+                                            "message": "계좌가 존재하지 않습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "422", description = "유효성 검사 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "stockPrice": "주식 가격은 필수 입력입니다.",
+                                            "tradeType": "매수/매도는 필수 선택입니다.",
+                                            "stockCode": "주식 코드는 필수 정보입니다.",
+                                            "stockCount": "주식 개수는 필수 입력입니다."
+                                        }
+                                    """)
+                    })),
+    })
+    ResponseEntity<?> tradeStock(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                 @Valid @RequestBody TradeReqDto tradeReqDto);
+}

--- a/src/main/java/muzusi/presentation/trade/controller/TradeController.java
+++ b/src/main/java/muzusi/presentation/trade/controller/TradeController.java
@@ -6,6 +6,7 @@ import muzusi.application.trade.dto.TradeReqDto;
 import muzusi.application.trade.service.StockTradeService;
 import muzusi.global.response.success.SuccessResponse;
 import muzusi.global.security.auth.CustomUserDetails;
+import muzusi.presentation.trade.api.TradeApi;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,9 +17,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/stocks")
 @RequiredArgsConstructor
-public class TradeController {
+public class TradeController implements TradeApi {
     private final StockTradeService stockTradeService;
 
+    @Override
     @PostMapping
     public ResponseEntity<?> tradeStock(@AuthenticationPrincipal CustomUserDetails userDetails,
                                         @Valid @RequestBody TradeReqDto tradeReqDto) {

--- a/src/main/java/muzusi/presentation/trade/controller/TradeController.java
+++ b/src/main/java/muzusi/presentation/trade/controller/TradeController.java
@@ -1,0 +1,29 @@
+package muzusi.presentation.trade.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import muzusi.application.trade.dto.TradeReqDto;
+import muzusi.application.trade.service.StockTradeService;
+import muzusi.global.response.success.SuccessResponse;
+import muzusi.global.security.auth.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/stocks")
+@RequiredArgsConstructor
+public class TradeController {
+    private final StockTradeService stockTradeService;
+
+    @PostMapping
+    public ResponseEntity<?> tradeStock(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                        @Valid @RequestBody TradeReqDto tradeReqDto) {
+        stockTradeService.tradeStock(userDetails.getUserId(), tradeReqDto);
+
+        return ResponseEntity.ok(SuccessResponse.ok());
+    }
+}


### PR DESCRIPTION
## 배경
- #44 

## 작업 사항
- 주식 매수/매도 로직 구현

## 추가 논의
 - 현재는 구매 예약이 없다는 상황을 가정하여 진행한 코드입니다. 추후에 예약을 구현하면 코드 로직상의 변화가 생깁니다!

## 테스트
- 주식 매수 성공
![image](https://github.com/user-attachments/assets/ad7a6f67-e0fa-41a7-937a-0cd414cfeb96)
- 주식 매도 성공
![image](https://github.com/user-attachments/assets/283ee4c5-9e9e-46c1-b25d-543b3f3970b6)
- 디비 저장 상태
![image](https://github.com/user-attachments/assets/c654b9ea-4f4e-440d-99a9-0dfd8838826b)

