### PR TITLE
Feature: 주식 거래 분기에 따른 처리

### DIFF
--- a/src/main/java/muzusi/application/account/service/AccountManagementService.java
+++ b/src/main/java/muzusi/application/account/service/AccountManagementService.java
@@ -11,8 +11,6 @@ import org.springframework.stereotype.Service;
 public class AccountManagementService {
     private final AccountService accountService;
 
-    private static final Long DEFAULT_BALANCE = 10_000_000L;
-
     /**
      * 새로운 계좌 연결하는 메서드.
      *
@@ -21,7 +19,7 @@ public class AccountManagementService {
     public void createAndLinkAccount(User user) {
         Account account = Account.builder()
                 .user(user)
-                .balance(DEFAULT_BALANCE)
+                .balance(Account.INITIAL_BALANCE)
                 .build();
 
         accountService.save(account);

--- a/src/main/java/muzusi/application/trade/dto/TradeReqDto.java
+++ b/src/main/java/muzusi/application/trade/dto/TradeReqDto.java
@@ -7,9 +7,13 @@ import muzusi.domain.trade.type.TradeType;
 
 @Schema(name = "TradeReqDto", description = "주식 매수/매도를 위한 DTO")
 public record TradeReqDto(
+        @Schema(description = "주식 현재 가격", example = "3000")
+        @NotNull
+        Long stockPrice,
+
         @Schema(description = "사용자가 입력한 가격", example = "3000")
         @NotNull(message = "주식 가격은 필수 입력입니다.")
-        Long stockPrice,
+        Long inputPrice,
 
         @Schema(description = "사용자가 입력한 매수/매도 개수", example = "3")
         @NotNull(message = "주식 개수는 필수 입력입니다.")

--- a/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
+++ b/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
@@ -1,0 +1,48 @@
+package muzusi.application.trade.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.stock.service.StockService;
+import muzusi.application.trade.dto.TradeReqDto;
+import muzusi.domain.account.entity.Account;
+import muzusi.domain.account.exception.AccountErrorType;
+import muzusi.domain.account.service.AccountService;
+import muzusi.domain.stock.entity.Stock;
+import muzusi.domain.stock.exception.StockErrorType;
+import muzusi.domain.trade.entity.Trade;
+import muzusi.domain.trade.service.TradeService;
+import muzusi.global.exception.CustomException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StockTradeExecutor {
+    private final TradeService tradeService;
+    private final StockService stockService;
+    private final AccountService accountService;
+
+    /**
+     * 주식 매수, 매도 메서드
+     *
+     * @param userId : 사용자 pk값
+     * @param tradeReqDto : trade 정보 dto
+     */
+    public void executeTrade(Long userId, TradeReqDto tradeReqDto) {
+        Account account = accountService.readByUserId(userId)
+                .orElseThrow(() -> new CustomException(AccountErrorType.NOT_FOUND));
+
+        Stock stock = stockService.readByStockCode(tradeReqDto.stockCode())
+                .orElseThrow(() -> new CustomException(StockErrorType.NOT_FOUND));
+
+        account.updateAccount(tradeReqDto.tradeType(), tradeReqDto.stockPrice() * tradeReqDto.stockCount());
+
+        tradeService.save(
+                Trade.builder()
+                        .stockPrice(tradeReqDto.stockPrice())
+                        .stockCount(tradeReqDto.stockCount())
+                        .tradeType(tradeReqDto.tradeType())
+                        .stock(stock)
+                        .account(account)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
+++ b/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
@@ -12,6 +12,7 @@ import muzusi.domain.trade.entity.Trade;
 import muzusi.domain.trade.service.TradeService;
 import muzusi.global.exception.CustomException;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -26,6 +27,7 @@ public class StockTradeExecutor {
      * @param userId : 사용자 pk값
      * @param tradeReqDto : trade 정보 dto
      */
+    @Transactional
     public void executeTrade(Long userId, TradeReqDto tradeReqDto) {
         Account account = accountService.readByUserId(userId)
                 .orElseThrow(() -> new CustomException(AccountErrorType.NOT_FOUND));

--- a/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
+++ b/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
@@ -35,8 +35,6 @@ public class StockTradeExecutor {
         Stock stock = stockService.readByStockCode(tradeReqDto.stockCode())
                 .orElseThrow(() -> new CustomException(StockErrorType.NOT_FOUND));
 
-        account.updateAccount(tradeReqDto.tradeType(), tradeReqDto.stockPrice() * tradeReqDto.stockCount());
-
         tradeService.save(
                 Trade.builder()
                         .stockPrice(tradeReqDto.stockPrice())

--- a/src/main/java/muzusi/application/trade/service/StockTradeService.java
+++ b/src/main/java/muzusi/application/trade/service/StockTradeService.java
@@ -1,48 +1,53 @@
 package muzusi.application.trade.service;
 
 import lombok.RequiredArgsConstructor;
-import muzusi.application.stock.service.StockService;
 import muzusi.application.trade.dto.TradeReqDto;
-import muzusi.domain.account.entity.Account;
-import muzusi.domain.account.exception.AccountErrorType;
-import muzusi.domain.account.service.AccountService;
-import muzusi.domain.stock.entity.Stock;
-import muzusi.domain.stock.exception.StockErrorType;
-import muzusi.domain.trade.entity.Trade;
-import muzusi.domain.trade.service.TradeService;
-import muzusi.global.exception.CustomException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class StockTradeService {
-    private final TradeService tradeService;
-    private final StockService stockService;
-    private final AccountService accountService;
+    private final StockTradeExecutor stockTradeExecutor;
+    private final TradeReservationHandler tradeReservationHandler;
 
     /**
-     * 주식 매수, 매도 메서드
+     * 주식 거래의 상태(매수/매도 가능 및 예약 처리)를 확인하는 메서드
      *
      * @param userId : 사용자 pk값
      * @param tradeReqDto : trade 정보 dto
      */
-    @Transactional
     public void tradeStock(Long userId, TradeReqDto tradeReqDto) {
-        Account account = accountService.readByUserId(userId)
-                .orElseThrow(() -> new CustomException(AccountErrorType.NOT_FOUND));
-
-        Stock stock = stockService.readByStockCode(tradeReqDto.stockCode())
-                .orElseThrow(() -> new CustomException(StockErrorType.NOT_FOUND));
-
-        tradeService.save(
-                Trade.builder()
-                        .stockPrice(tradeReqDto.stockPrice())
-                        .stockCount(tradeReqDto.stockCount())
-                        .tradeType(tradeReqDto.tradeType())
-                        .stock(stock)
-                        .account(account)
-                        .build()
-        );
+        switch (tradeReqDto.tradeType()) {
+            case BUY -> processBuyTrade(userId, tradeReqDto);
+            case SELL -> processSellTrade(userId, tradeReqDto);
+            default -> throw new IllegalArgumentException("잘못된 거래 유형입니다.");
+        }
     }
+
+    /**
+     * 주식을 사는 메서드.
+     * 사용자 입력 값 >= 주식 가격 : 주식 거래 성사
+     * 사용자 입력 값 < 주식 가격 : 주식 거래 예약
+     */
+    private void processBuyTrade(Long userId, TradeReqDto tradeReqDto) {
+        if (tradeReqDto.inputPrice() >= tradeReqDto.stockPrice()) {
+            stockTradeExecutor.executeTrade(userId, tradeReqDto);
+        } else {
+            tradeReservationHandler.saveTradeReservation(userId, tradeReqDto);
+        }
+    }
+
+    /**
+     * 주식을 파는 메서드.
+     * 사용자 입력 값 <= 주식 가격 : 주식 거래 성사
+     * 사용자 입력 값 > 주식 가격 : 주식 거래 예약
+     */
+    private void processSellTrade(Long userId, TradeReqDto tradeReqDto) {
+        if (tradeReqDto.inputPrice() <= tradeReqDto.stockPrice()) {
+            stockTradeExecutor.executeTrade(userId, tradeReqDto);
+        } else {
+            tradeReservationHandler.saveTradeReservation(userId, tradeReqDto);
+        }
+    }
+
 }

--- a/src/main/java/muzusi/application/trade/service/TradeReservationHandler.java
+++ b/src/main/java/muzusi/application/trade/service/TradeReservationHandler.java
@@ -1,0 +1,31 @@
+package muzusi.application.trade.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.trade.dto.TradeReqDto;
+import muzusi.domain.trade.entity.TradeReservation;
+import muzusi.domain.trade.service.TradeReservationService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TradeReservationHandler {
+    private final TradeReservationService tradeReservationService;
+
+    /**
+     * 성사가 안된 주식 거래를 예약 처리하는 메서드
+     *
+     * @param userId : 사용자 pk값
+     * @param tradeReqDto : trade 정보 dto
+     */
+    public void saveTradeReservation(Long userId, TradeReqDto tradeReqDto) {
+        TradeReservation reservation = TradeReservation.builder()
+                .userId(userId)
+                .inputPrice(tradeReqDto.inputPrice())
+                .stockCount(tradeReqDto.stockCount())
+                .stockCode(tradeReqDto.stockCode())
+                .tradeType(tradeReqDto.tradeType())
+                .build();
+
+        tradeReservationService.save(reservation);
+    }
+}

--- a/src/main/java/muzusi/domain/account/entity/Account.java
+++ b/src/main/java/muzusi/domain/account/entity/Account.java
@@ -13,7 +13,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import muzusi.domain.trade.type.TradeType;
 import muzusi.domain.user.entity.User;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
@@ -50,20 +49,5 @@ public class Account {
     public Account(Long balance, User user) {
         this.balance = balance;
         this.user = user;
-    }
-
-    /**
-     * 주식 거래로 인한 계좌 업데이트
-     *
-     * @param tradeType : 거래 타입
-     * @param price : 변화할 가격
-     */
-    public void updateAccount(TradeType tradeType, Long price) {
-        switch (tradeType) {
-            case BUY -> balance -= price;
-            case SELL -> balance += price;
-        }
-
-        rateOfReturn = (double) (balance - INITIAL_BALANCE) / INITIAL_BALANCE * 100;
     }
 }

--- a/src/main/java/muzusi/domain/account/entity/Account.java
+++ b/src/main/java/muzusi/domain/account/entity/Account.java
@@ -13,7 +13,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import muzusi.domain.trade.type.TradeType;
 import muzusi.domain.user.entity.User;
+import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -23,6 +25,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @Entity(name = "account")
+@DynamicUpdate
 public class Account {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -47,5 +50,20 @@ public class Account {
     public Account(Long balance, User user) {
         this.balance = balance;
         this.user = user;
+    }
+
+    /**
+     * 주식 거래로 인한 계좌 업데이트
+     *
+     * @param tradeType : 거래 타입
+     * @param price : 변화할 가격
+     */
+    public void updateAccount(TradeType tradeType, Long price) {
+        switch (tradeType) {
+            case BUY -> balance -= price;
+            case SELL -> balance += price;
+        }
+
+        rateOfReturn = (double) (balance - INITIAL_BALANCE) / INITIAL_BALANCE * 100;
     }
 }

--- a/src/main/java/muzusi/domain/account/entity/Account.java
+++ b/src/main/java/muzusi/domain/account/entity/Account.java
@@ -28,6 +28,8 @@ public class Account {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    public static final Long INITIAL_BALANCE = 10_000_000L;
+
     private Long balance;
 
     @Column(name = "rate_of_return")

--- a/src/main/java/muzusi/domain/trade/entity/TradeReservation.java
+++ b/src/main/java/muzusi/domain/trade/entity/TradeReservation.java
@@ -1,0 +1,42 @@
+package muzusi.domain.trade.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import muzusi.domain.trade.type.TradeType;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "trade_reservation")
+public class TradeReservation {
+    @Id
+    private String id;
+
+    private Long userId;
+
+    private Long inputPrice;
+
+    private Integer stockCount;
+
+    private String stockCode;
+
+    private TradeType tradeType;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Builder
+    public TradeReservation(Long userId, Long inputPrice, Integer stockCount, String stockCode, TradeType tradeType) {
+        this.userId = userId;
+        this.inputPrice = inputPrice;
+        this.stockCount = stockCount;
+        this.stockCode = stockCode;
+        this.tradeType = tradeType;
+    }
+}

--- a/src/main/java/muzusi/domain/trade/repository/TradeReservationRepository.java
+++ b/src/main/java/muzusi/domain/trade/repository/TradeReservationRepository.java
@@ -1,0 +1,7 @@
+package muzusi.domain.trade.repository;
+
+import muzusi.domain.trade.entity.TradeReservation;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface TradeReservationRepository extends MongoRepository<TradeReservation, String> {
+}

--- a/src/main/java/muzusi/domain/trade/service/TradeReservationService.java
+++ b/src/main/java/muzusi/domain/trade/service/TradeReservationService.java
@@ -1,0 +1,16 @@
+package muzusi.domain.trade.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.trade.entity.TradeReservation;
+import muzusi.domain.trade.repository.TradeReservationRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TradeReservationService {
+    private final TradeReservationRepository tradeReservationRepository;
+
+    public void save(TradeReservation reservation) {
+        tradeReservationRepository.save(reservation);
+    }
+}

--- a/src/main/java/muzusi/infrastructure/config/MongoConfig.java
+++ b/src/main/java/muzusi/infrastructure/config/MongoConfig.java
@@ -7,9 +7,11 @@ import muzusi.infrastructure.properties.MongoProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 
 @Configuration
 @RequiredArgsConstructor
+@EnableMongoAuditing
 public class MongoConfig extends AbstractMongoClientConfiguration {
 
     private final MongoProperties mongoProperties;


### PR DESCRIPTION
## 배경
- close #44 

## 작업 사항
- 주식 거래 상태에 따른 분기 처리 (거래 성사 및 거래 예약)

## 추가 논의
- Trade Entity에 주문 시간 필드 추후에 추가하겠습니다.
- 매수된 내역을 관리하는 Entity가 필요할 것 같습니다.
- 카톡에서 얘기한 것 처럼, 예약 처리건은 차트표시를 위해 값을 불러오는 과정에서 처리하면 될 것 같습니다!

## 테스트
- 거래가 불가능하여 예약처리를 MongoDB에 넣은 사진
<img width="477" alt="스크린샷 2025-01-16 오전 1 51 01" src="https://github.com/user-attachments/assets/af133aac-607b-4607-b93a-7b5dfde6010b" />

