### PR TITLE
Feature: Jwt Payload 정보 추가

### DIFF
--- a/src/main/java/muzusi/application/auth/dto/SignUpDto.java
+++ b/src/main/java/muzusi/application/auth/dto/SignUpDto.java
@@ -1,10 +1,12 @@
 package muzusi.application.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
 
 @Schema(name = "SignUpDto", description = "회원가입 DTO")
 public record SignUpDto(
         @Schema(description = "낙네임", example = "test")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]{2,8}$", message = "2~8자의 한글, 영문, 숫자(공백, 특수문자 제외)")
         String nickname
 ) {
 }

--- a/src/main/java/muzusi/application/auth/helper/JwtHelper.java
+++ b/src/main/java/muzusi/application/auth/helper/JwtHelper.java
@@ -21,9 +21,10 @@ public class JwtHelper {
     public TokenDto createToken(User user) {
         Long userId = user.getId();
         String username = user.getUsername();
+        String nickname = user.getNickname();
 
-        String accessToken = jwtProvider.generateAccessToken(username, userId);
-        String refreshToken = jwtProvider.generateRefreshToken(username, userId);
+        String accessToken = jwtProvider.generateAccessToken(username, nickname, userId);
+        String refreshToken = jwtProvider.generateRefreshToken(username, nickname, userId);
 
         refreshTokenService.saveRefreshToken(username, refreshToken);
 
@@ -36,10 +37,11 @@ public class JwtHelper {
         if (!refreshTokenService.existedRefreshToken(username))
             throw new CustomException(CommonErrorType.REFRESH_TOKEN_NOT_FOUND);
 
+        String nickname = jwtProvider.getNickname(refreshToken);
         Long userId = jwtProvider.getUserId(refreshToken);
 
-        String newAccessToken = jwtProvider.generateAccessToken(username, userId);
-        String newRefreshToken = jwtProvider.generateRefreshToken(username, userId);
+        String newAccessToken = jwtProvider.generateAccessToken(username, nickname, userId);
+        String newRefreshToken = jwtProvider.generateRefreshToken(username, nickname, userId);
 
         refreshTokenService.saveRefreshToken(username, newRefreshToken);
 

--- a/src/main/java/muzusi/application/auth/service/AuthService.java
+++ b/src/main/java/muzusi/application/auth/service/AuthService.java
@@ -85,13 +85,16 @@ public class AuthService {
      *
      * @param userId : 사용자 PK값
      * @param signUpDto : 회원정보 dto
+     * @return : jwt token
      */
     @Transactional
-    public void signUp(Long userId, SignUpDto signUpDto) {
+    public TokenDto signUp(Long userId, SignUpDto signUpDto) {
         User foundUser = userService.readById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
 
         userService.update(foundUser, signUpDto.nickname());
+
+        return jwtHelper.createToken(foundUser);
     }
 
     /**

--- a/src/main/java/muzusi/global/security/jwt/JwtProvider.java
+++ b/src/main/java/muzusi/global/security/jwt/JwtProvider.java
@@ -47,9 +47,9 @@ public class JwtProvider {
      * @param userId : Token payload에 담을 정보
      * @return : accessToken
      */
-    public String generateAccessToken(String username, Long userId) {
+    public String generateAccessToken(String username, String nickname, Long userId) {
 
-        return createJwt(createClaims(userId), username, accessExpiration);
+        return createJwt(createClaims(userId, nickname), username, accessExpiration);
     }
 
     /**
@@ -59,9 +59,9 @@ public class JwtProvider {
      * @param userId : Token payload에 담을 정보
      * @return : refreshToken
      */
-    public String generateRefreshToken(String username, Long userId) {
+    public String generateRefreshToken(String username, String nickname, Long userId) {
 
-        return createJwt(createClaims(userId), username, refreshExpiration);
+        return createJwt(createClaims(userId, nickname), username, refreshExpiration);
     }
 
     /**
@@ -70,9 +70,10 @@ public class JwtProvider {
      * @param userId : claim에 담을 정보
      * @return : claims
      */
-    private Map<String, Object> createClaims(Long userId) {
+    private Map<String, Object> createClaims(Long userId, String nickname) {
         Map<String, Object> claims = new HashMap<>();
         claims.put("userId", userId);
+        claims.put("nickname", nickname);
         return claims;
     }
 
@@ -132,6 +133,16 @@ public class JwtProvider {
      */
     public String getUsername(String token) {
         return parseClaims(token).getSubject();
+    }
+
+    /**
+     * 토큰의 Payload(Subject)를 추출하는 메서드
+     *
+     * @param token : 토큰
+     * @return : Subject
+     */
+    public String getNickname(String token) {
+        return parseClaims(token).get("nickname", String.class);
     }
 
     /**

--- a/src/main/java/muzusi/presentation/auth/api/AuthApi.java
+++ b/src/main/java/muzusi/presentation/auth/api/AuthApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import muzusi.application.auth.dto.OAuthCodeDto;
 import muzusi.application.auth.dto.SignUpDto;
 import muzusi.domain.user.type.OAuthPlatform;
@@ -31,13 +32,24 @@ public interface AuthApi {
                             @ExampleObject(value = """
                                         {
                                             "code": 200,
-                                            "message": "요청이 성공하였습니다."
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                "accessToken": "<access token>"
+                                            }
                                         }
                                     """)
-                    }))
+                    })),
+            @ApiResponse(responseCode = "422", description = "유효성 검사 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "nickname": "2~8자의 한글, 영문, 숫자(공백, 특수문자 제외)"
+                                        }
+                                    """)
+                    })),
     })
     ResponseEntity<?> signUp(@AuthenticationPrincipal CustomUserDetails userDetails,
-                             @RequestBody SignUpDto signUpDto);
+                             @Valid @RequestBody SignUpDto signUpDto);
 
     @TrackApi(description = "소셜 로그인")
     @Operation(summary = "소셜 로그인", description = "서비스를 이용하기 위해 로그인하는 API입니다.")
@@ -46,14 +58,22 @@ public interface AuthApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(name = "FirstLogin", value = """
                                         {
-                                            "accessToken": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0NiIsbGUiOiJPV05FUiIsImNhdGVnb3J5IjoizIiwidXNlcklkIjo2LCJpYXQiOjE3MjI2Njc1MzYsImV4cCI6MTcyMjY2OTMzNn0.9eY_1aSfKLfDhKN5X4f85N2hv_I65QOPFtq_2YXEhoA",
-                                            "isRegistered": false
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                "accessToken": "<access token>",
+                                                "isRegistered": false
+                                            }
                                         }
                                     """),
                             @ExampleObject(name = "ReturningLogin", value = """
                                         {
-                                            "accessToken": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0NiIsInJvbGUiOiJPV05FUihdGVnb3J5IjoiYWNjZXNlcklkIjo2LCJpYXQiOjE3MjI2Njc1MzYsImV4cCI6MTcyMjY2OTMzNn0.9eY_1aSfKLfDhKN5X4f85N2hv_I65QOPFtq_2YXEhoA",
-                                            "isRegistered": true
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                "accessToken": "<access token>",
+                                                "isRegistered": true
+                                            }
                                         }
                                     """)
                     }))
@@ -68,7 +88,11 @@ public interface AuthApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                         {
-                                            "accessToken": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0NiIsbGUiOiJPV05FUiIsImNhdGVnb3J5IjoizIiwidXNlcklkIjo2LCJpYXQiOjE3MjI2Njc1MzYsImV4cCI6MTcyMjY2OTMzNn0.9eY_1aSfKLfDhKN5X4f85N2hv_I65QOPFtq_2YXEhoA"
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                "accessToken": "<access token>"
+                                            }
                                         }
                                     """)
                     })),

--- a/src/main/java/muzusi/presentation/auth/controller/AuthController.java
+++ b/src/main/java/muzusi/presentation/auth/controller/AuthController.java
@@ -40,7 +40,7 @@ public class AuthController implements AuthApi {
     @Override
     @PostMapping("/sign-up")
     public ResponseEntity<?> signUp(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                    @RequestBody SignUpDto signUpDto) {
+                                    @Valid @RequestBody SignUpDto signUpDto) {
 
         return createTokenRes(authService.signUp(userDetails.getUserId(), signUpDto));
     }

--- a/src/main/java/muzusi/presentation/auth/controller/AuthController.java
+++ b/src/main/java/muzusi/presentation/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package muzusi.presentation.auth.controller;
 
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import muzusi.application.auth.dto.LoginDto;
 import muzusi.application.auth.dto.OAuthCodeDto;
@@ -40,8 +41,8 @@ public class AuthController implements AuthApi {
     @PostMapping("/sign-up")
     public ResponseEntity<?> signUp(@AuthenticationPrincipal CustomUserDetails userDetails,
                                     @RequestBody SignUpDto signUpDto) {
-        authService.signUp(userDetails.getUserId(), signUpDto);
-        return ResponseEntity.ok(SuccessResponse.ok());
+
+        return createTokenRes(authService.signUp(userDetails.getUserId(), signUpDto));
     }
 
     @Override


### PR DESCRIPTION
## 배경
 - UI상 닉네임을 보여주기 위한 Jwt Payload에 정보 추가

## 작업 사항
- Jwt Payload에 Nickname 정보 추가
- 회원가입시, token 재발급
- 회원가입 유효성검사 추가

## 추가 논의
- 최초 로그인 시, 닉네임은 서버에서 임의로 지정한 값이 디폴트로 들어가기 때문에 회원가입 시 token을 재발급해주었습니다.
- 프론트 측에서는 Access Token으로 닉네임을 추출하여 사용하면 될 것 같습니다. (추출 후 로컬 스토리지 등에 저장 후 사용?)
- 추가적으로, 정보 설정에서 닉네임을 업데이트 할 시, 위에서 말한 방식으로 닉네임을 업데이트 하면 될 것 같습니다. (로컬 스토리즈의 닉네임 값 업데이트)
- p.s. 닉네임 유효성 검사는 프론트 측 문구를 보고 똑같이 하였습니다.