### PR TITLE
Feature: 매수된 주식 관리 및 매수/매도 로직 처리

### DIFF
--- a/src/main/java/muzusi/application/account/dto/AccountInfoDto.java
+++ b/src/main/java/muzusi/application/account/dto/AccountInfoDto.java
@@ -4,10 +4,9 @@ import muzusi.domain.account.entity.Account;
 
 public record AccountInfoDto(
         Long id,
-        Long balance,
-        double rateOfReturn
+        Long balance
 ) {
     public static AccountInfoDto fromEntity(Account account) {
-        return new AccountInfoDto(account.getId(), account.getBalance(), account.getRateOfReturn());
+        return new AccountInfoDto(account.getId(), account.getBalance());
     }
 }

--- a/src/main/java/muzusi/application/trade/dto/TradeReqDto.java
+++ b/src/main/java/muzusi/application/trade/dto/TradeReqDto.java
@@ -1,6 +1,7 @@
 package muzusi.application.trade.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import muzusi.domain.trade.type.TradeType;
@@ -8,7 +9,7 @@ import muzusi.domain.trade.type.TradeType;
 @Schema(name = "TradeReqDto", description = "주식 매수/매도를 위한 DTO")
 public record TradeReqDto(
         @Schema(description = "주식 현재 가격", example = "3000")
-        @NotNull
+        @NotNull(message = "주식 현재 가격은 필수 입력입니다.")
         Long stockPrice,
 
         @Schema(description = "사용자가 입력한 가격", example = "3000")
@@ -17,6 +18,7 @@ public record TradeReqDto(
 
         @Schema(description = "사용자가 입력한 매수/매도 개수", example = "3")
         @NotNull(message = "주식 개수는 필수 입력입니다.")
+        @Min(value = 1, message = "주식 개수는 1개 이상이어야 합니다.")
         Integer stockCount,
 
         @Schema(description = "주식 코드", example = "000610")

--- a/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
+++ b/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
@@ -103,7 +103,7 @@ public class StockTradeExecutor {
         holding.sellStock(tradeReqDto.stockCount());
 
         if (holding.isEmpty())
-            holdingService.deleteByStockCode(tradeReqDto.stockCode());
+            holdingService.deleteByUserIdAndStockCode(userId, tradeReqDto.stockCode());
 
         long price = tradeReqDto.stockPrice() * tradeReqDto.stockCount();
         account.updateAccount(tradeReqDto.tradeType(), price);

--- a/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
+++ b/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
@@ -71,7 +71,7 @@ public class StockTradeExecutor {
         long price = tradeReqDto.stockPrice() * tradeReqDto.stockCount();
         account.updateAccount(tradeReqDto.tradeType(), price);
 
-        if (!holdingService.existsByStockCode(tradeReqDto.stockCode())) {
+        if (!holdingService.existsByUserIdAndStockCode(userId, tradeReqDto.stockCode())) {
             User foundUser = userService.readById(userId)
                             .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
 

--- a/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
+++ b/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
@@ -6,10 +6,14 @@ import muzusi.application.trade.dto.TradeReqDto;
 import muzusi.domain.account.entity.Account;
 import muzusi.domain.account.exception.AccountErrorType;
 import muzusi.domain.account.service.AccountService;
+import muzusi.domain.holding.entity.Holding;
+import muzusi.domain.holding.exception.HoldingErrorType;
+import muzusi.domain.holding.service.HoldingService;
 import muzusi.domain.stock.entity.Stock;
 import muzusi.domain.stock.exception.StockErrorType;
 import muzusi.domain.trade.entity.Trade;
 import muzusi.domain.trade.service.TradeService;
+import muzusi.domain.trade.type.TradeType;
 import muzusi.global.exception.CustomException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +24,7 @@ public class StockTradeExecutor {
     private final TradeService tradeService;
     private final StockService stockService;
     private final AccountService accountService;
+    private final HoldingService holdingService;
 
     /**
      * 주식 매수, 매도 메서드
@@ -31,6 +36,12 @@ public class StockTradeExecutor {
     public void executeTrade(Long userId, TradeReqDto tradeReqDto) {
         Account account = accountService.readByUserId(userId)
                 .orElseThrow(() -> new CustomException(AccountErrorType.NOT_FOUND));
+
+        if (tradeReqDto.tradeType() == TradeType.BUY)
+            handleStockPurchase(tradeReqDto, account);
+
+        if (tradeReqDto.tradeType() == TradeType.SELL)
+            handleStockSale(tradeReqDto, account);
 
         Stock stock = stockService.readByStockCode(tradeReqDto.stockCode())
                 .orElseThrow(() -> new CustomException(StockErrorType.NOT_FOUND));
@@ -44,5 +55,51 @@ public class StockTradeExecutor {
                         .account(account)
                         .build()
         );
+    }
+
+    /**
+     * 매수에 대한 내역 처리 메서드
+     * 해당 주식에 대한 내역이 있다 -> 그 데이터를 기반으로 업데이트
+     * 해당 주식에 대한 내역이 없다 -> 새로운 관리 데이터 생성
+     *
+     * @param tradeReqDto : trade 정보 dto
+     * @param account : 연결된 계좌
+     */
+    private void handleStockPurchase(TradeReqDto tradeReqDto, Account account) {
+        if (!holdingService.existsByStockCode(tradeReqDto.stockCode())) {
+            holdingService.save(
+                    Holding.builder()
+                            .stockCode(tradeReqDto.stockCode())
+                            .stockCount(tradeReqDto.stockCount())
+                            .averagePrice(tradeReqDto.stockPrice())
+                            .account(account)
+                            .build()
+            );
+        } else {
+            Holding holding = holdingService.readByStockCode(tradeReqDto.stockCode()).get();
+            holding.addStock(tradeReqDto.stockCount(), tradeReqDto.stockPrice());
+        }
+
+        account.updateAccount(tradeReqDto.tradeType(), tradeReqDto.stockPrice(), tradeReqDto.stockCount());
+    }
+
+    /**
+     * 매도에 대한 내역 처리 메서드
+     * 매도로 인해 주식의 수량이 0이 되면 삭제.
+     *
+     * @param tradeReqDto : trade 정보 dto
+     * @param account : 연결된 계좌
+     */
+    private void handleStockSale(TradeReqDto tradeReqDto, Account account) {
+        Holding holding = holdingService.readByStockCode(tradeReqDto.stockCode())
+                .orElseThrow(() -> new CustomException(HoldingErrorType.NOT_FOUND));
+
+        if (!holding.sellStock(tradeReqDto.stockCount()))
+            throw new CustomException(HoldingErrorType.INSUFFICIENT_STOCK);
+
+        if (holding.isEmpty())
+            holdingService.deleteByStockCode(tradeReqDto.stockCode());
+
+        account.updateAccount(tradeReqDto.tradeType(), tradeReqDto.stockPrice(), tradeReqDto.stockCount());
     }
 }

--- a/src/main/java/muzusi/application/trade/service/StockTradeService.java
+++ b/src/main/java/muzusi/application/trade/service/StockTradeService.java
@@ -64,7 +64,7 @@ public class StockTradeService {
      * 사용자 입력 값 > 주식 가격 : 주식 거래 예약
      */
     private void processSellTrade(Long userId, TradeReqDto tradeReqDto) {
-        Holding holding = holdingService.readByStockCode(tradeReqDto.stockCode())
+        Holding holding = holdingService.readByUserIdAndStockCode(userId, tradeReqDto.stockCode())
                 .orElseThrow(() -> new CustomException(HoldingErrorType.NOT_FOUND));
 
         if (holding.getStockCount() < tradeReqDto.stockCount())

--- a/src/main/java/muzusi/application/trade/service/StockTradeService.java
+++ b/src/main/java/muzusi/application/trade/service/StockTradeService.java
@@ -2,13 +2,23 @@ package muzusi.application.trade.service;
 
 import lombok.RequiredArgsConstructor;
 import muzusi.application.trade.dto.TradeReqDto;
+import muzusi.domain.account.entity.Account;
+import muzusi.domain.account.exception.AccountErrorType;
+import muzusi.domain.account.service.AccountService;
+import muzusi.domain.holding.entity.Holding;
+import muzusi.domain.holding.exception.HoldingErrorType;
+import muzusi.domain.holding.service.HoldingService;
+import muzusi.global.exception.CustomException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class StockTradeService {
     private final StockTradeExecutor stockTradeExecutor;
     private final TradeReservationHandler tradeReservationHandler;
+    private final AccountService accountService;
+    private final HoldingService holdingService;
 
     /**
      * 주식 거래의 상태(매수/매도 가능 및 예약 처리)를 확인하는 메서드
@@ -16,6 +26,7 @@ public class StockTradeService {
      * @param userId : 사용자 pk값
      * @param tradeReqDto : trade 정보 dto
      */
+    @Transactional
     public void tradeStock(Long userId, TradeReqDto tradeReqDto) {
         switch (tradeReqDto.tradeType()) {
             case BUY -> processBuyTrade(userId, tradeReqDto);
@@ -26,10 +37,19 @@ public class StockTradeService {
 
     /**
      * 주식을 사는 메서드.
+     * 보유 잔액이 매수하고자 하는 금액보다 적다 -> 예외처리
      * 사용자 입력 값 >= 주식 가격 : 주식 거래 성사
      * 사용자 입력 값 < 주식 가격 : 주식 거래 예약
      */
     private void processBuyTrade(Long userId, TradeReqDto tradeReqDto) {
+        Account account = accountService.readByUserId(userId)
+                .orElseThrow(() -> new CustomException(AccountErrorType.NOT_FOUND));
+
+        long requiredAmount = tradeReqDto.stockPrice() * tradeReqDto.stockCount();
+
+        if (account.getBalance() < requiredAmount)
+            throw new CustomException(AccountErrorType.INSUFFICIENT_BALANCE);
+
         if (tradeReqDto.inputPrice() >= tradeReqDto.stockPrice()) {
             stockTradeExecutor.executeTrade(userId, tradeReqDto);
         } else {
@@ -39,10 +59,17 @@ public class StockTradeService {
 
     /**
      * 주식을 파는 메서드.
+     * 보유 주식 수량이 매도하고자 하는 개수보다 적다 -> 예외처리
      * 사용자 입력 값 <= 주식 가격 : 주식 거래 성사
      * 사용자 입력 값 > 주식 가격 : 주식 거래 예약
      */
     private void processSellTrade(Long userId, TradeReqDto tradeReqDto) {
+        Holding holding = holdingService.readByStockCode(tradeReqDto.stockCode())
+                .orElseThrow(() -> new CustomException(HoldingErrorType.NOT_FOUND));
+
+        if (holding.getStockCount() < tradeReqDto.stockCount())
+            throw new CustomException(HoldingErrorType.INSUFFICIENT_STOCK);
+
         if (tradeReqDto.inputPrice() <= tradeReqDto.stockPrice()) {
             stockTradeExecutor.executeTrade(userId, tradeReqDto);
         } else {

--- a/src/main/java/muzusi/application/trade/service/TradeReservationHandler.java
+++ b/src/main/java/muzusi/application/trade/service/TradeReservationHandler.java
@@ -65,9 +65,7 @@ public class TradeReservationHandler {
         Holding holding = holdingService.readByUserIdAndStockCode(userId, tradeReqDto.stockCode())
                 .orElseThrow(() -> new CustomException(HoldingErrorType.NOT_FOUND));
 
-        holding.sellStock(tradeReqDto.stockCount());
-
-        if (holding.isEmpty())
-            holdingService.deleteByStockCode(tradeReqDto.stockCode());
+        if (!holding.reserveSellStock(tradeReqDto.stockCount()))
+            throw new CustomException(HoldingErrorType.INSUFFICIENT_STOCK);
     }
 }

--- a/src/main/java/muzusi/application/trade/service/TradeReservationHandler.java
+++ b/src/main/java/muzusi/application/trade/service/TradeReservationHandler.java
@@ -29,7 +29,7 @@ public class TradeReservationHandler {
     public void saveTradeReservation(Long userId, TradeReqDto tradeReqDto) {
         switch (tradeReqDto.tradeType()) {
             case BUY -> handleReservationPurchase(tradeReqDto, userId);
-            case SELL -> handleReservationSale(tradeReqDto);
+            case SELL -> handleReservationSale(tradeReqDto, userId);
             default -> throw new IllegalArgumentException("잘못된 거래 유형입니다.");
         }
 
@@ -61,8 +61,8 @@ public class TradeReservationHandler {
      * 매도 예약 처리
      * 사용자가 보유한 주식 수량을 차감한다
      */
-    private void handleReservationSale(TradeReqDto tradeReqDto) {
-        Holding holding = holdingService.readByStockCode(tradeReqDto.stockCode())
+    private void handleReservationSale(TradeReqDto tradeReqDto, Long userId) {
+        Holding holding = holdingService.readByUserIdAndStockCode(userId, tradeReqDto.stockCode())
                 .orElseThrow(() -> new CustomException(HoldingErrorType.NOT_FOUND));
 
         holding.sellStock(tradeReqDto.stockCount());

--- a/src/main/java/muzusi/application/trade/service/TradeReservationHandler.java
+++ b/src/main/java/muzusi/application/trade/service/TradeReservationHandler.java
@@ -2,14 +2,23 @@ package muzusi.application.trade.service;
 
 import lombok.RequiredArgsConstructor;
 import muzusi.application.trade.dto.TradeReqDto;
+import muzusi.domain.account.entity.Account;
+import muzusi.domain.account.exception.AccountErrorType;
+import muzusi.domain.account.service.AccountService;
+import muzusi.domain.holding.entity.Holding;
+import muzusi.domain.holding.exception.HoldingErrorType;
+import muzusi.domain.holding.service.HoldingService;
 import muzusi.domain.trade.entity.TradeReservation;
 import muzusi.domain.trade.service.TradeReservationService;
+import muzusi.global.exception.CustomException;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class TradeReservationHandler {
     private final TradeReservationService tradeReservationService;
+    private final AccountService accountService;
+    private final HoldingService holdingService;
 
     /**
      * 성사가 안된 주식 거래를 예약 처리하는 메서드
@@ -18,6 +27,12 @@ public class TradeReservationHandler {
      * @param tradeReqDto : trade 정보 dto
      */
     public void saveTradeReservation(Long userId, TradeReqDto tradeReqDto) {
+        switch (tradeReqDto.tradeType()) {
+            case BUY -> handleReservationPurchase(tradeReqDto, userId);
+            case SELL -> handleReservationSale(tradeReqDto);
+            default -> throw new IllegalArgumentException("잘못된 거래 유형입니다.");
+        }
+
         TradeReservation reservation = TradeReservation.builder()
                 .userId(userId)
                 .inputPrice(tradeReqDto.inputPrice())
@@ -27,5 +42,32 @@ public class TradeReservationHandler {
                 .build();
 
         tradeReservationService.save(reservation);
+    }
+
+    /**
+     * 매수 예약 처리 메서드
+     * 계좌 잔액을 차감한다.
+     */
+    private void handleReservationPurchase(TradeReqDto tradeReqDto, Long userId) {
+        Account account = accountService.readByUserId(userId)
+                .orElseThrow(() -> new CustomException(AccountErrorType.NOT_FOUND));
+
+        long price = tradeReqDto.inputPrice() * tradeReqDto.stockCount();
+
+        account.updateAccount(tradeReqDto.tradeType(), price);
+    }
+
+    /**
+     * 매도 예약 처리
+     * 사용자가 보유한 주식 수량을 차감한다
+     */
+    private void handleReservationSale(TradeReqDto tradeReqDto) {
+        Holding holding = holdingService.readByStockCode(tradeReqDto.stockCode())
+                .orElseThrow(() -> new CustomException(HoldingErrorType.NOT_FOUND));
+
+        holding.sellStock(tradeReqDto.stockCount());
+
+        if (holding.isEmpty())
+            holdingService.deleteByStockCode(tradeReqDto.stockCode());
     }
 }

--- a/src/main/java/muzusi/domain/account/entity/Account.java
+++ b/src/main/java/muzusi/domain/account/entity/Account.java
@@ -13,6 +13,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import muzusi.domain.trade.type.TradeType;
 import muzusi.domain.user.entity.User;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
@@ -34,9 +35,6 @@ public class Account {
 
     private Long balance;
 
-    @Column(name = "rate_of_return")
-    private double rateOfReturn;
-
     @Column(name = "created_at")
     @CreatedDate
     private LocalDateTime createdAt;
@@ -49,5 +47,19 @@ public class Account {
     public Account(Long balance, User user) {
         this.balance = balance;
         this.user = user;
+    }
+
+    /**
+     * 주식 거래로 인한 계좌 업데이트
+     *
+     * @param tradeType : 거래 타입
+     * @param stockPrice : 주식 가격
+     * @param stockCount : 거래 개수
+     */
+    public void updateAccount(TradeType tradeType, Long stockPrice, Integer stockCount) {
+        switch (tradeType) {
+            case BUY -> balance -= stockPrice * stockCount;
+            case SELL -> balance += stockPrice * stockCount;
+        }
     }
 }

--- a/src/main/java/muzusi/domain/account/entity/Account.java
+++ b/src/main/java/muzusi/domain/account/entity/Account.java
@@ -53,13 +53,12 @@ public class Account {
      * 주식 거래로 인한 계좌 업데이트
      *
      * @param tradeType : 거래 타입
-     * @param stockPrice : 주식 가격
-     * @param stockCount : 거래 개수
+     * @param price : 거래 금액
      */
-    public void updateAccount(TradeType tradeType, Long stockPrice, Integer stockCount) {
+    public void updateAccount(TradeType tradeType, Long price) {
         switch (tradeType) {
-            case BUY -> balance -= stockPrice * stockCount;
-            case SELL -> balance += stockPrice * stockCount;
+            case BUY -> balance -= price;
+            case SELL -> balance += price;
         }
     }
 }

--- a/src/main/java/muzusi/domain/account/exception/AccountErrorType.java
+++ b/src/main/java/muzusi/domain/account/exception/AccountErrorType.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
  */
 @RequiredArgsConstructor
 public enum AccountErrorType implements BaseErrorType {
-    NOT_FOUND(HttpStatus.NOT_FOUND, "4001", "계좌가 존재하지 않습니다.")
+    NOT_FOUND(HttpStatus.NOT_FOUND, "4001", "계좌가 존재하지 않습니다."),
+    INSUFFICIENT_BALANCE(HttpStatus.BAD_REQUEST, "4002", "계좌 잔액이 부족합니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/muzusi/domain/holding/entity/Holding.java
+++ b/src/main/java/muzusi/domain/holding/entity/Holding.java
@@ -13,6 +13,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import muzusi.domain.account.entity.Account;
+import muzusi.domain.user.entity.User;
 import org.hibernate.annotations.DynamicUpdate;
 
 @Getter
@@ -34,14 +35,19 @@ public class Holding {
     private Long averagePrice;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "account_id")
     private Account account;
 
     @Builder
-    public Holding(String stockCode, Integer stockCount, Long averagePrice, Account account) {
+    public Holding(String stockCode, Integer stockCount, Long averagePrice, User user, Account account) {
         this.stockCode = stockCode;
         this.stockCount = stockCount;
         this.averagePrice = averagePrice;
+        this.user = user;
         this.account = account;
     }
 
@@ -57,12 +63,8 @@ public class Holding {
     /**
      * 주식을 매도할 때 수량을 차감하는 메서드
      */
-    public boolean sellStock(int count) {
-        if (this.stockCount < count) {
-            return false;
-        }
+    public void sellStock(int count) {
         this.stockCount -= count;
-        return true;
     }
 
     /**

--- a/src/main/java/muzusi/domain/holding/entity/Holding.java
+++ b/src/main/java/muzusi/domain/holding/entity/Holding.java
@@ -31,6 +31,9 @@ public class Holding {
     @Column(name = "stock_count", nullable = false)
     private Integer stockCount;
 
+    @Column(name = "reserved_stock_count", columnDefinition = "INT DEFAULT 0")
+    private Integer reservedStockCount = 0;
+
     @Column(name = "average_price", nullable = false)
     private Long averagePrice;
 
@@ -65,6 +68,32 @@ public class Holding {
      */
     public void sellStock(int count) {
         this.stockCount -= count;
+    }
+
+    /**
+     * 예약 매도를 추가하는 메서드
+     */
+    public boolean reserveSellStock(int count) {
+        if (count > this.stockCount - this.reservedStockCount) {
+            return false;
+        }
+        this.reservedStockCount += count;
+        return true;
+    }
+
+    /**
+     * 예약 매도를 취소하는 메서드
+     */
+    public void cancelReservedSell(int count) {
+        this.reservedStockCount -= count;
+    }
+
+    /**
+     * 예약 매도가 확정되었을 때 실제 보유 주식에서 차감
+     */
+    public void confirmReservedSell(int count) {
+        sellStock(this.reservedStockCount);
+        this.reservedStockCount -= count;
     }
 
     /**

--- a/src/main/java/muzusi/domain/holding/entity/Holding.java
+++ b/src/main/java/muzusi/domain/holding/entity/Holding.java
@@ -1,0 +1,74 @@
+package muzusi.domain.holding.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import muzusi.domain.account.entity.Account;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "holding")
+@DynamicUpdate
+public class Holding {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "stock_code", nullable = false)
+    private String stockCode;
+
+    @Column(name = "stock_count", nullable = false)
+    private Integer stockCount;
+
+    @Column(name = "average_price", nullable = false)
+    private Long averagePrice;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id")
+    private Account account;
+
+    @Builder
+    public Holding(String stockCode, Integer stockCount, Long averagePrice, Account account) {
+        this.stockCode = stockCode;
+        this.stockCount = stockCount;
+        this.averagePrice = averagePrice;
+        this.account = account;
+    }
+
+    /**
+     * 주식을 추가 매수할 때 평균 단가를 재계산하는 메서드
+     */
+    public void addStock(int count, long price) {
+        long totalCost = (this.stockCount * this.averagePrice) + (count * price);
+        this.stockCount += count;
+        this.averagePrice = totalCost / this.stockCount;
+    }
+
+    /**
+     * 주식을 매도할 때 수량을 차감하는 메서드
+     */
+    public boolean sellStock(int count) {
+        if (this.stockCount < count) {
+            return false;
+        }
+        this.stockCount -= count;
+        return true;
+    }
+
+    /**
+     * 보유 수량이 0이면 삭제할 수 있도록 체크하는 메서드
+     */
+    public boolean isEmpty() {
+        return this.stockCount == 0;
+    }
+}

--- a/src/main/java/muzusi/domain/holding/exception/HoldingErrorType.java
+++ b/src/main/java/muzusi/domain/holding/exception/HoldingErrorType.java
@@ -1,0 +1,34 @@
+package muzusi.domain.holding.exception;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.global.response.error.type.BaseErrorType;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Holding ErrorCode: 5xxx
+ */
+@RequiredArgsConstructor
+public enum HoldingErrorType implements BaseErrorType {
+    NOT_FOUND(HttpStatus.NOT_FOUND, "5001", "매수내역이 없습니다."),
+    INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "5002", "잔여 주식이 부족합니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/muzusi/domain/holding/repository/HoldingRepository.java
+++ b/src/main/java/muzusi/domain/holding/repository/HoldingRepository.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 
 public interface HoldingRepository extends JpaRepository<Holding, Long> {
     Optional<Holding> findByUser_IdAndStockCode(Long userId, String stockCode);
-    boolean existsByStockCode(String stockCode);
+    boolean existsByUser_IdAndStockCode(Long userId, String stockCode);
     void deleteByStockCode(String stockCode);
 }

--- a/src/main/java/muzusi/domain/holding/repository/HoldingRepository.java
+++ b/src/main/java/muzusi/domain/holding/repository/HoldingRepository.java
@@ -1,0 +1,12 @@
+package muzusi.domain.holding.repository;
+
+import muzusi.domain.holding.entity.Holding;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface HoldingRepository extends JpaRepository<Holding, Long> {
+    Optional<Holding> findByStockCode(String stockCode);
+    boolean existsByStockCode(String stockCode);
+    void deleteByStockCode(String stockCode);
+}

--- a/src/main/java/muzusi/domain/holding/repository/HoldingRepository.java
+++ b/src/main/java/muzusi/domain/holding/repository/HoldingRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface HoldingRepository extends JpaRepository<Holding, Long> {
-    Optional<Holding> findByStockCode(String stockCode);
+    Optional<Holding> findByUser_IdAndStockCode(Long userId, String stockCode);
     boolean existsByStockCode(String stockCode);
     void deleteByStockCode(String stockCode);
 }

--- a/src/main/java/muzusi/domain/holding/repository/HoldingRepository.java
+++ b/src/main/java/muzusi/domain/holding/repository/HoldingRepository.java
@@ -2,11 +2,31 @@ package muzusi.domain.holding.repository;
 
 import muzusi.domain.holding.entity.Holding;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface HoldingRepository extends JpaRepository<Holding, Long> {
-    Optional<Holding> findByUser_IdAndStockCode(Long userId, String stockCode);
-    boolean existsByUser_IdAndStockCode(Long userId, String stockCode);
-    void deleteByStockCode(String stockCode);
+    @Query(value = "SELECT h.* FROM holding h " +
+            "JOIN account a ON h.account_id = a.id " +
+            "WHERE a.id = (SELECT id FROM account WHERE user_id = :userId ORDER BY created_at DESC LIMIT 1) " +
+            "AND h.stock_code = :stockCode ", nativeQuery = true)
+    Optional<Holding> findLatestAccountHolding(@Param("userId") Long userId, @Param("stockCode") String stockCode);
+
+    @Query(value = "SELECT EXISTS ( " +
+            "SELECT 1 FROM holding h " +
+            "JOIN account a ON h.account_id = a.id " +
+            "WHERE a.id = (SELECT id FROM account WHERE user_id = :userId ORDER BY created_at DESC LIMIT 1) " +
+            "AND h.stock_code = :stockCode) ", nativeQuery = true)
+    Integer existsByLatestAccountHolding(@Param("userId") Long userId, @Param("stockCode") String stockCode);
+
+    @Modifying
+    @Query(value = "DELETE FROM holding " +
+            "WHERE account_id = (SELECT id FROM account WHERE user_id = :userId ORDER BY created_at DESC LIMIT 1 )" +
+            "AND stock_code = :stockCode", nativeQuery = true)
+    void deleteByLatestAccountHolding(@Param("userId") Long userId, @Param("stockCode") String stockCode);
+
+
 }

--- a/src/main/java/muzusi/domain/holding/service/HoldingService.java
+++ b/src/main/java/muzusi/domain/holding/service/HoldingService.java
@@ -17,14 +17,14 @@ public class HoldingService {
     }
 
     public Optional<Holding> readByUserIdAndStockCode(Long userId, String stockCode) {
-        return holdingRepository.findByUser_IdAndStockCode(userId, stockCode);
+        return holdingRepository.findLatestAccountHolding(userId, stockCode);
     }
 
     public boolean existsByUserIdAndStockCode(Long userId, String stockCode) {
-        return holdingRepository.existsByUser_IdAndStockCode(userId, stockCode);
+        return holdingRepository.existsByLatestAccountHolding(userId, stockCode) == 1;
     }
 
-    public void deleteByStockCode(String stockCode) {
-        holdingRepository.deleteByStockCode(stockCode);
+    public void deleteByUserIdAndStockCode(Long userId, String stockCode) {
+        holdingRepository.deleteByLatestAccountHolding(userId, stockCode);
     }
 }

--- a/src/main/java/muzusi/domain/holding/service/HoldingService.java
+++ b/src/main/java/muzusi/domain/holding/service/HoldingService.java
@@ -1,0 +1,30 @@
+package muzusi.domain.holding.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.holding.entity.Holding;
+import muzusi.domain.holding.repository.HoldingRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class HoldingService {
+    private final HoldingRepository holdingRepository;
+
+    public void save(Holding holding) {
+        holdingRepository.save(holding);
+    }
+
+    public Optional<Holding> readByStockCode(String stockCode) {
+        return holdingRepository.findByStockCode(stockCode);
+    }
+
+    public boolean existsByStockCode(String stockCode) {
+        return holdingRepository.existsByStockCode(stockCode);
+    }
+
+    public void deleteByStockCode(String stockCode) {
+        holdingRepository.deleteByStockCode(stockCode);
+    }
+}

--- a/src/main/java/muzusi/domain/holding/service/HoldingService.java
+++ b/src/main/java/muzusi/domain/holding/service/HoldingService.java
@@ -20,8 +20,8 @@ public class HoldingService {
         return holdingRepository.findByUser_IdAndStockCode(userId, stockCode);
     }
 
-    public boolean existsByStockCode(String stockCode) {
-        return holdingRepository.existsByStockCode(stockCode);
+    public boolean existsByUserIdAndStockCode(Long userId, String stockCode) {
+        return holdingRepository.existsByUser_IdAndStockCode(userId, stockCode);
     }
 
     public void deleteByStockCode(String stockCode) {

--- a/src/main/java/muzusi/domain/holding/service/HoldingService.java
+++ b/src/main/java/muzusi/domain/holding/service/HoldingService.java
@@ -16,8 +16,8 @@ public class HoldingService {
         holdingRepository.save(holding);
     }
 
-    public Optional<Holding> readByStockCode(String stockCode) {
-        return holdingRepository.findByStockCode(stockCode);
+    public Optional<Holding> readByUserIdAndStockCode(Long userId, String stockCode) {
+        return holdingRepository.findByUser_IdAndStockCode(userId, stockCode);
     }
 
     public boolean existsByStockCode(String stockCode) {

--- a/src/main/java/muzusi/domain/stock/entity/Stock.java
+++ b/src/main/java/muzusi/domain/stock/entity/Stock.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import muzusi.domain.stock.type.MarketType;
@@ -32,4 +33,12 @@ public class Stock {
 
     @Column(name = "industry", nullable = false)
     private String industry;
+
+    @Builder
+    public Stock(String stockName, String stockCode, MarketType marketType, String industry) {
+        this.stockName = stockName;
+        this.stockCode = stockCode;
+        this.marketType = marketType;
+        this.industry = industry;
+    }
 }

--- a/src/main/java/muzusi/presentation/trade/api/TradeApi.java
+++ b/src/main/java/muzusi/presentation/trade/api/TradeApi.java
@@ -31,12 +31,18 @@ public interface TradeApi {
                                         }
                                     """)
                     })),
-            @ApiResponse(responseCode = "400", description = "잘못된 잔여 주식 요청",
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(value = """
+                            @ExampleObject(name = "InsufficientStock", value = """
                                         {
                                             "code": "5002",
                                             "message": "잔여 주식이 부족합니다."
+                                        }
+                                    """),
+                            @ExampleObject(name = "InsufficientBalance", value = """
+                                        {
+                                            "code": "4002",
+                                            "message": "계좌 잔액이 부족합니다."
                                         }
                                     """)
                     })),

--- a/src/main/java/muzusi/presentation/trade/api/TradeApi.java
+++ b/src/main/java/muzusi/presentation/trade/api/TradeApi.java
@@ -31,7 +31,16 @@ public interface TradeApi {
                                         }
                                     """)
                     })),
-            @ApiResponse(responseCode = "404", description = "주식 존재 x ",
+            @ApiResponse(responseCode = "400", description = "잘못된 잔여 주식 요청",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": "5002",
+                                            "message": "잔여 주식이 부족합니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "Not Found 관련",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(name = "NotFoundStock", value = """
                                         {
@@ -43,6 +52,12 @@ public interface TradeApi {
                                         {
                                             "code": "4001",
                                             "message": "계좌가 존재하지 않습니다."
+                                        }
+                                    """),
+                            @ExampleObject(name = "NotFoundHolding", value = """
+                                        {
+                                            "code": "5001",
+                                            "message": "매수내역이 없습니다."
                                         }
                                     """)
                     })),

--- a/src/test/java/muzusi/application/trade/service/StockTradeExecutorTest.java
+++ b/src/test/java/muzusi/application/trade/service/StockTradeExecutorTest.java
@@ -1,0 +1,215 @@
+package muzusi.application.trade.service;
+
+import muzusi.application.stock.service.StockService;
+import muzusi.application.trade.dto.TradeReqDto;
+import muzusi.domain.account.entity.Account;
+import muzusi.domain.account.exception.AccountErrorType;
+import muzusi.domain.account.service.AccountService;
+import muzusi.domain.holding.entity.Holding;
+import muzusi.domain.holding.exception.HoldingErrorType;
+import muzusi.domain.holding.service.HoldingService;
+import muzusi.domain.stock.entity.Stock;
+import muzusi.domain.trade.entity.Trade;
+import muzusi.domain.trade.service.TradeService;
+import muzusi.domain.trade.type.TradeType;
+import muzusi.global.exception.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class StockTradeExecutorTest {
+
+    @InjectMocks
+    private StockTradeExecutor stockTradeExecutor;
+
+    @Mock
+    private TradeService tradeService;
+    @Mock
+    private StockService stockService;
+    @Mock
+    private AccountService accountService;
+    @Mock
+    private HoldingService holdingService;
+
+    private TradeReqDto buyTradeDto;
+    private TradeReqDto sellTradeDto;
+    private Account account;
+    private Stock stock;
+    private Holding holding;
+
+    @BeforeEach
+    void setUp() {
+        buyTradeDto = new TradeReqDto(3000L, 3000L, 5, "000610", TradeType.BUY);
+        sellTradeDto = new TradeReqDto(3000L, 3000L, 3, "000610", TradeType.SELL);
+
+        account = Account.builder()
+                .balance(Account.INITIAL_BALANCE)
+                .build();
+
+        stock = Stock.builder()
+                .stockName("삼성전자")
+                .stockCode("000610")
+                .build();
+
+        holding = Holding.builder()
+                .stockCode("000610")
+                .stockCount(10)
+                .averagePrice(2900L)
+                .account(account)
+                .build();
+    }
+
+    @Test
+    @DisplayName("매수 실행 테스트 - 새로운 내역 추가")
+    void executeTradeBuyNewHolding() {
+        // given
+        given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
+        given(stockService.readByStockCode(buyTradeDto.stockCode())).willReturn(Optional.of(stock));
+        given(holdingService.existsByStockCode(buyTradeDto.stockCode())).willReturn(false);
+
+        // when
+        stockTradeExecutor.executeTrade(1L, buyTradeDto);
+
+        // then
+        assertEquals(Account.INITIAL_BALANCE - (buyTradeDto.stockPrice() * buyTradeDto.stockCount()), account.getBalance());
+        verify(holdingService, times(1)).save(any(Holding.class));
+        verify(tradeService, times(1)).save(any(Trade.class));
+    }
+
+    @Test
+    @DisplayName("매수 실행 테스트 - 기존 보유 주식 업데이트")
+    void executeTradeBuyExistingHolding() {
+        // given
+        given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
+        given(stockService.readByStockCode(buyTradeDto.stockCode())).willReturn(Optional.of(stock));
+        given(holdingService.existsByStockCode(buyTradeDto.stockCode())).willReturn(true);
+        given(holdingService.readByStockCode(buyTradeDto.stockCode())).willReturn(Optional.of(holding));
+
+        int prevStockCount = holding.getStockCount();
+        long prevTotalCost = prevStockCount * holding.getAveragePrice();
+
+        // when
+        stockTradeExecutor.executeTrade(1L, buyTradeDto);
+
+        // then
+        int expectedStockCount = prevStockCount + buyTradeDto.stockCount();
+        long expectedTotalCost = prevTotalCost + (buyTradeDto.stockCount() * buyTradeDto.stockPrice());
+        long expectedAveragePrice = expectedTotalCost / expectedStockCount;
+
+        assertEquals(Account.INITIAL_BALANCE - (buyTradeDto.stockPrice() * buyTradeDto.stockCount()), account.getBalance());
+        assertEquals(expectedStockCount, holding.getStockCount());
+        assertEquals(expectedAveragePrice, holding.getAveragePrice());
+
+        verify(holdingService, never()).save(any(Holding.class));
+        verify(tradeService, times(1)).save(any(Trade.class));
+    }
+
+    @Test
+    @DisplayName("매수 실행 실패 - 잔액 부족")
+    void executeTradeBuyFailInsufficientBalance() {
+        // given
+        Account lowBalanceAccount = Account.builder()
+                .balance(5000L)
+                .user(null)
+                .build();
+
+        given(accountService.readByUserId(1L)).willReturn(Optional.of(lowBalanceAccount));
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () ->
+                stockTradeExecutor.executeTrade(1L, buyTradeDto)
+        );
+
+        // then
+        assertEquals(AccountErrorType.INSUFFICIENT_BALANCE.getStatus(), exception.getErrorType().getStatus());
+        assertEquals(AccountErrorType.INSUFFICIENT_BALANCE.getCode(), exception.getErrorType().getCode());
+        assertEquals(AccountErrorType.INSUFFICIENT_BALANCE.getMessage(), exception.getErrorType().getMessage());
+    }
+
+    @Test
+    @DisplayName("매도 실행 테스트 - 충분한 수량 보유")
+    void executeTradeSellSuccess() {
+        // given
+        given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
+        given(stockService.readByStockCode(sellTradeDto.stockCode())).willReturn(Optional.of(stock));
+        given(holdingService.readByStockCode(sellTradeDto.stockCode())).willReturn(Optional.of(holding));
+
+        // when
+        stockTradeExecutor.executeTrade(1L, sellTradeDto);
+
+        // then
+        assertEquals(Account.INITIAL_BALANCE + (sellTradeDto.stockPrice() * sellTradeDto.stockCount()), account.getBalance());
+        verify(holdingService, never()).deleteByStockCode(sellTradeDto.stockCode());
+        verify(tradeService, times(1)).save(any(Trade.class));
+    }
+
+    @Test
+    @DisplayName("매도 실행 실패 - 보유 주식 없음")
+    void executeTradeSellFailNoHolding() {
+        // given
+        given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () ->
+                stockTradeExecutor.executeTrade(1L, sellTradeDto)
+        );
+
+        // then
+        assertEquals(HoldingErrorType.NOT_FOUND.getStatus(), exception.getErrorType().getStatus());
+        assertEquals(HoldingErrorType.NOT_FOUND.getCode(), exception.getErrorType().getCode());
+        assertEquals(HoldingErrorType.NOT_FOUND.getMessage(), exception.getErrorType().getMessage());
+    }
+
+    @Test
+    @DisplayName("매도 실행 실패 - 보유 주식 부족")
+    void executeTradeSellFailInsufficientStock() {
+        // given
+        given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
+        given(holdingService.readByStockCode(sellTradeDto.stockCode())).willReturn(Optional.of(holding));
+
+        TradeReqDto invalidSellTradeDto = new TradeReqDto(3000L, 3000L, 100, "000610", TradeType.SELL);
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () ->
+                stockTradeExecutor.executeTrade(1L, invalidSellTradeDto)
+        );
+
+        // then
+        assertEquals(HoldingErrorType.INSUFFICIENT_STOCK.getStatus(), exception.getErrorType().getStatus());
+        assertEquals(HoldingErrorType.INSUFFICIENT_STOCK.getCode(), exception.getErrorType().getCode());
+        assertEquals(HoldingErrorType.INSUFFICIENT_STOCK.getMessage(), exception.getErrorType().getMessage());
+    }
+
+    @Test
+    @DisplayName("매도 실행 테스트 - 보유 주식이 0이 되면 삭제")
+    void executeTradeSellDeleteHoldingWhenZero() {
+        // given
+        TradeReqDto fullSellTradeDto = new TradeReqDto(3000L, 3000L, holding.getStockCount(), "000610", TradeType.SELL);
+
+        given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
+        given(stockService.readByStockCode(fullSellTradeDto.stockCode())).willReturn(Optional.of(stock));
+        given(holdingService.readByStockCode(fullSellTradeDto.stockCode())).willReturn(Optional.of(holding));
+
+        // when
+        stockTradeExecutor.executeTrade(1L, fullSellTradeDto);
+
+        // then
+        verify(holdingService, times(1)).deleteByStockCode(fullSellTradeDto.stockCode());
+        verify(tradeService, times(1)).save(any(Trade.class));
+    }
+}

--- a/src/test/java/muzusi/application/trade/service/StockTradeExecutorTest.java
+++ b/src/test/java/muzusi/application/trade/service/StockTradeExecutorTest.java
@@ -142,7 +142,7 @@ class StockTradeExecutorTest {
 
         // then
         assertEquals(Account.INITIAL_BALANCE + (sellTradeDto.stockPrice() * sellTradeDto.stockCount()), account.getBalance());
-        verify(holdingService, never()).deleteByStockCode(sellTradeDto.stockCode());
+        verify(holdingService, never()).deleteByUserIdAndStockCode(1L, sellTradeDto.stockCode());
         verify(tradeService, times(1)).save(any(Trade.class));
     }
 
@@ -178,7 +178,7 @@ class StockTradeExecutorTest {
         stockTradeExecutor.executeTrade(1L, fullSellTradeDto);
 
         // then
-        verify(holdingService, times(1)).deleteByStockCode(fullSellTradeDto.stockCode());
+        verify(holdingService, times(1)).deleteByUserIdAndStockCode(1L, fullSellTradeDto.stockCode());
         verify(tradeService, times(1)).save(any(Trade.class));
     }
 }

--- a/src/test/java/muzusi/application/trade/service/StockTradeExecutorTest.java
+++ b/src/test/java/muzusi/application/trade/service/StockTradeExecutorTest.java
@@ -90,7 +90,7 @@ class StockTradeExecutorTest {
         given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
         given(stockService.readByStockCode(buyTradeDto.stockCode())).willReturn(Optional.of(stock));
         given(userService.readById(1L)).willReturn(Optional.of(user));
-        given(holdingService.existsByStockCode(buyTradeDto.stockCode())).willReturn(false);
+        given(holdingService.existsByUserIdAndStockCode(1L, buyTradeDto.stockCode())).willReturn(false);
 
         // when
         stockTradeExecutor.executeTrade(1L, buyTradeDto);
@@ -107,7 +107,7 @@ class StockTradeExecutorTest {
         // given
         given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
         given(stockService.readByStockCode(buyTradeDto.stockCode())).willReturn(Optional.of(stock));
-        given(holdingService.existsByStockCode(buyTradeDto.stockCode())).willReturn(true);
+        given(holdingService.existsByUserIdAndStockCode(1L, buyTradeDto.stockCode())).willReturn(true);
         given(holdingService.readByUserIdAndStockCode(1L, buyTradeDto.stockCode())).willReturn(Optional.of(holding));
 
         int prevStockCount = holding.getStockCount();

--- a/src/test/java/muzusi/application/trade/service/StockTradeServiceTest.java
+++ b/src/test/java/muzusi/application/trade/service/StockTradeServiceTest.java
@@ -1,0 +1,89 @@
+package muzusi.application.trade.service;
+
+import muzusi.application.trade.dto.TradeReqDto;
+import muzusi.domain.trade.type.TradeType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class StockTradeServiceTest {
+
+    @InjectMocks
+    private StockTradeService stockTradeService;
+
+    @Mock
+    private StockTradeExecutor stockTradeExecutor;
+    @Mock
+    private TradeReservationHandler tradeReservationHandler;
+
+    private TradeReqDto buyTradeDto;
+    private TradeReqDto sellTradeDto;
+
+    @BeforeEach
+    void setUp() {
+        buyTradeDto = new TradeReqDto(3000L, 3100L, 5, "000610", TradeType.BUY);
+        sellTradeDto = new TradeReqDto(3000L, 2900L, 3, "000610", TradeType.SELL);
+    }
+
+    @Test
+    @DisplayName("즉시 매수 테스트")
+    void tradeStockBuyExecute() {
+        // given
+
+        // when
+        stockTradeService.tradeStock(1L, buyTradeDto);
+
+        // then
+        verify(stockTradeExecutor, times(1)).executeTrade(1L, buyTradeDto);
+        verify(tradeReservationHandler, never()).saveTradeReservation(anyLong(), any(TradeReqDto.class));
+    }
+
+    @Test
+    @DisplayName("매수 예약 테스트")
+    void tradeStockBuyReservation() {
+        // given
+        TradeReqDto buyReservationDto = new TradeReqDto(3000L, 2900L, 5, "000610", TradeType.BUY);
+
+        // when
+        stockTradeService.tradeStock(1L, buyReservationDto);
+
+        // then
+        verify(stockTradeExecutor, never()).executeTrade(anyLong(), any(TradeReqDto.class));
+        verify(tradeReservationHandler, times(1)).saveTradeReservation(1L, buyReservationDto);
+    }
+
+    @Test
+    @DisplayName("즉시 매도 테스트")
+    void tradeStockSellExecute() {
+        // when
+        stockTradeService.tradeStock(1L, sellTradeDto);
+
+        // then
+        verify(stockTradeExecutor, times(1)).executeTrade(1L, sellTradeDto);
+        verify(tradeReservationHandler, never()).saveTradeReservation(anyLong(), any(TradeReqDto.class));
+    }
+
+    @Test
+    @DisplayName("매도 예약 테스트")
+    void tradeStockSellReservation() {
+        // given
+        TradeReqDto sellReservationDto = new TradeReqDto(3000L, 3100L, 3, "000610", TradeType.SELL);
+        // when
+        stockTradeService.tradeStock(1L, sellReservationDto);
+
+        // then
+        verify(stockTradeExecutor, never()).executeTrade(anyLong(), any(TradeReqDto.class));
+        verify(tradeReservationHandler, times(1)).saveTradeReservation(1L, sellReservationDto);
+    }
+}

--- a/src/test/java/muzusi/application/trade/service/StockTradeServiceTest.java
+++ b/src/test/java/muzusi/application/trade/service/StockTradeServiceTest.java
@@ -1,7 +1,14 @@
 package muzusi.application.trade.service;
 
 import muzusi.application.trade.dto.TradeReqDto;
+import muzusi.domain.account.entity.Account;
+import muzusi.domain.account.exception.AccountErrorType;
+import muzusi.domain.account.service.AccountService;
+import muzusi.domain.holding.entity.Holding;
+import muzusi.domain.holding.exception.HoldingErrorType;
+import muzusi.domain.holding.service.HoldingService;
 import muzusi.domain.trade.type.TradeType;
+import muzusi.global.exception.CustomException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,8 +17,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -26,20 +38,38 @@ class StockTradeServiceTest {
     private StockTradeExecutor stockTradeExecutor;
     @Mock
     private TradeReservationHandler tradeReservationHandler;
+    @Mock
+    private AccountService accountService;
+    @Mock
+    private HoldingService holdingService;
 
     private TradeReqDto buyTradeDto;
     private TradeReqDto sellTradeDto;
+    private Account account;
+    private Holding holding;
 
     @BeforeEach
     void setUp() {
         buyTradeDto = new TradeReqDto(3000L, 3100L, 5, "000610", TradeType.BUY);
         sellTradeDto = new TradeReqDto(3000L, 2900L, 3, "000610", TradeType.SELL);
+
+        account = Account.builder()
+                .balance(Account.INITIAL_BALANCE)
+                .build();
+
+        holding = Holding.builder()
+                .stockCode("000610")
+                .stockCount(10)
+                .averagePrice(2900L)
+                .account(account)
+                .build();
     }
 
     @Test
     @DisplayName("즉시 매수 테스트")
     void tradeStockBuyExecute() {
         // given
+        given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
 
         // when
         stockTradeService.tradeStock(1L, buyTradeDto);
@@ -54,6 +84,7 @@ class StockTradeServiceTest {
     void tradeStockBuyReservation() {
         // given
         TradeReqDto buyReservationDto = new TradeReqDto(3000L, 2900L, 5, "000610", TradeType.BUY);
+        given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
 
         // when
         stockTradeService.tradeStock(1L, buyReservationDto);
@@ -64,8 +95,33 @@ class StockTradeServiceTest {
     }
 
     @Test
+    @DisplayName("매수 실행 실패 - 잔액 부족")
+    void executeTradeBuyFailInsufficientBalance() {
+        // given
+        Account lowBalanceAccount = Account.builder()
+                .balance(5000L)
+                .user(null)
+                .build();
+
+        given(accountService.readByUserId(1L)).willReturn(Optional.of(lowBalanceAccount));
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () ->
+                stockTradeService.tradeStock(1L, buyTradeDto)
+        );
+
+        // then
+        assertEquals(AccountErrorType.INSUFFICIENT_BALANCE.getStatus(), exception.getErrorType().getStatus());
+        assertEquals(AccountErrorType.INSUFFICIENT_BALANCE.getCode(), exception.getErrorType().getCode());
+        assertEquals(AccountErrorType.INSUFFICIENT_BALANCE.getMessage(), exception.getErrorType().getMessage());
+    }
+
+    @Test
     @DisplayName("즉시 매도 테스트")
     void tradeStockSellExecute() {
+        // given
+        given(holdingService.readByUserIdAndStockCode(1L, buyTradeDto.stockCode())).willReturn(Optional.of(holding));
+
         // when
         stockTradeService.tradeStock(1L, sellTradeDto);
 
@@ -79,11 +135,31 @@ class StockTradeServiceTest {
     void tradeStockSellReservation() {
         // given
         TradeReqDto sellReservationDto = new TradeReqDto(3000L, 3100L, 3, "000610", TradeType.SELL);
+        given(holdingService.readByUserIdAndStockCode(1L, buyTradeDto.stockCode())).willReturn(Optional.of(holding));
+
         // when
         stockTradeService.tradeStock(1L, sellReservationDto);
 
         // then
         verify(stockTradeExecutor, never()).executeTrade(anyLong(), any(TradeReqDto.class));
         verify(tradeReservationHandler, times(1)).saveTradeReservation(1L, sellReservationDto);
+    }
+
+    @Test
+    @DisplayName("매도 실행 실패 - 보유 주식 부족")
+    void executeTradeSellFailInsufficientStock() {
+        // given
+        given(holdingService.readByUserIdAndStockCode(1L, sellTradeDto.stockCode())).willReturn(Optional.of(holding));
+        TradeReqDto invalidSellTradeDto = new TradeReqDto(3000L, 3000L, 100, "000610", TradeType.SELL);
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () ->
+                stockTradeService.tradeStock(1L, invalidSellTradeDto)
+        );
+
+        // then
+        assertEquals(HoldingErrorType.INSUFFICIENT_STOCK.getStatus(), exception.getErrorType().getStatus());
+        assertEquals(HoldingErrorType.INSUFFICIENT_STOCK.getCode(), exception.getErrorType().getCode());
+        assertEquals(HoldingErrorType.INSUFFICIENT_STOCK.getMessage(), exception.getErrorType().getMessage());
     }
 }

--- a/src/test/java/muzusi/application/trade/service/TradeReservationHandlerTest.java
+++ b/src/test/java/muzusi/application/trade/service/TradeReservationHandlerTest.java
@@ -72,7 +72,7 @@ class TradeReservationHandlerTest {
         tradeReservationHandler.saveTradeReservation(1L, buyTradeDto);
 
         // then
-        assertEquals(Account.INITIAL_BALANCE - (buyTradeDto.stockPrice() * buyTradeDto.stockCount()), account.getBalance());
+        assertEquals(Account.INITIAL_BALANCE - (buyTradeDto.inputPrice() * buyTradeDto.stockCount()), account.getBalance());
         verify(tradeReservationService, times(1)).save(any(TradeReservation.class));
     }
 

--- a/src/test/java/muzusi/application/trade/service/TradeReservationHandlerTest.java
+++ b/src/test/java/muzusi/application/trade/service/TradeReservationHandlerTest.java
@@ -4,10 +4,12 @@ import muzusi.application.trade.dto.TradeReqDto;
 import muzusi.domain.account.entity.Account;
 import muzusi.domain.account.service.AccountService;
 import muzusi.domain.holding.entity.Holding;
+import muzusi.domain.holding.exception.HoldingErrorType;
 import muzusi.domain.holding.service.HoldingService;
 import muzusi.domain.trade.entity.TradeReservation;
 import muzusi.domain.trade.service.TradeReservationService;
 import muzusi.domain.trade.type.TradeType;
+import muzusi.global.exception.CustomException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
@@ -44,8 +47,8 @@ class TradeReservationHandlerTest {
 
     @BeforeEach
     void setUp() {
-        buyTradeDto = new TradeReqDto(3000L, 3000L, 5, "000610", TradeType.BUY);
-        sellTradeDto = new TradeReqDto(3000L, 3000L, 3, "000610", TradeType.SELL);
+        buyTradeDto = new TradeReqDto(3500L, 3000L, 5, "000610", TradeType.BUY);
+        sellTradeDto = new TradeReqDto(2500L, 3000L, 3, "000610", TradeType.SELL);
 
         account = Account.builder()
                 .balance(Account.INITIAL_BALANCE)
@@ -84,5 +87,23 @@ class TradeReservationHandlerTest {
 
         // then
         verify(tradeReservationService, times(1)).save(any(TradeReservation.class));
+    }
+
+    @Test
+    @DisplayName("매도 예약 실패 테스트 - 수량 부족")
+    void handleReservationSaleFalseTest() {
+        // given
+        TradeReqDto overCountDto = new TradeReqDto(2500L, 3000L, 15, "000610", TradeType.SELL);
+        given(holdingService.readByUserIdAndStockCode(1L, buyTradeDto.stockCode())).willReturn(Optional.of(holding));
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () ->
+                tradeReservationHandler.saveTradeReservation(1L, overCountDto)
+        );
+
+        // then
+        assertEquals(HoldingErrorType.INSUFFICIENT_STOCK.getStatus(), exception.getErrorType().getStatus());
+        assertEquals(HoldingErrorType.INSUFFICIENT_STOCK.getCode(), exception.getErrorType().getCode());
+        assertEquals(HoldingErrorType.INSUFFICIENT_STOCK.getMessage(), exception.getErrorType().getMessage());
     }
 }

--- a/src/test/java/muzusi/application/trade/service/TradeReservationHandlerTest.java
+++ b/src/test/java/muzusi/application/trade/service/TradeReservationHandlerTest.java
@@ -1,0 +1,46 @@
+package muzusi.application.trade.service;
+
+import muzusi.application.trade.dto.TradeReqDto;
+import muzusi.domain.trade.entity.TradeReservation;
+import muzusi.domain.trade.service.TradeReservationService;
+import muzusi.domain.trade.type.TradeType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TradeReservationHandlerTest {
+
+    @InjectMocks
+    private TradeReservationHandler tradeReservationHandler;
+
+    @Mock
+    private TradeReservationService tradeReservationService;
+
+    private TradeReqDto tradeReqDto;
+
+    @BeforeEach
+    void setUp() {
+        tradeReqDto = new TradeReqDto(3000L, 2900L, 5, "000610", TradeType.BUY);
+    }
+
+    @Test
+    @DisplayName("거래 예약 저장 테스트")
+    void saveTradeReservationSuccess() {
+        // given
+
+        // when
+        tradeReservationHandler.saveTradeReservation(1L, tradeReqDto);
+
+        // then
+        verify(tradeReservationService, times(1)).save(any(TradeReservation.class));
+    }
+}

--- a/src/test/java/muzusi/application/trade/service/TradeReservationHandlerTest.java
+++ b/src/test/java/muzusi/application/trade/service/TradeReservationHandlerTest.java
@@ -1,6 +1,10 @@
 package muzusi.application.trade.service;
 
 import muzusi.application.trade.dto.TradeReqDto;
+import muzusi.domain.account.entity.Account;
+import muzusi.domain.account.service.AccountService;
+import muzusi.domain.holding.entity.Holding;
+import muzusi.domain.holding.service.HoldingService;
 import muzusi.domain.trade.entity.TradeReservation;
 import muzusi.domain.trade.service.TradeReservationService;
 import muzusi.domain.trade.type.TradeType;
@@ -12,7 +16,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -24,21 +32,55 @@ class TradeReservationHandlerTest {
 
     @Mock
     private TradeReservationService tradeReservationService;
+    @Mock
+    private AccountService accountService;
+    @Mock
+    private HoldingService holdingService;
 
-    private TradeReqDto tradeReqDto;
+    private TradeReqDto buyTradeDto;
+    private TradeReqDto sellTradeDto;
+    private Account account;
+    private Holding holding;
 
     @BeforeEach
     void setUp() {
-        tradeReqDto = new TradeReqDto(3000L, 2900L, 5, "000610", TradeType.BUY);
+        buyTradeDto = new TradeReqDto(3000L, 3000L, 5, "000610", TradeType.BUY);
+        sellTradeDto = new TradeReqDto(3000L, 3000L, 3, "000610", TradeType.SELL);
+
+        account = Account.builder()
+                .balance(Account.INITIAL_BALANCE)
+                .build();
+
+        holding = Holding.builder()
+                .stockCode("000610")
+                .stockCount(10)
+                .averagePrice(2900L)
+                .account(account)
+                .build();
     }
 
     @Test
-    @DisplayName("거래 예약 저장 테스트")
-    void saveTradeReservationSuccess() {
+    @DisplayName("매수 예약 저장 테스트")
+    void handleReservationPurchaseTest() {
         // given
+        given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
 
         // when
-        tradeReservationHandler.saveTradeReservation(1L, tradeReqDto);
+        tradeReservationHandler.saveTradeReservation(1L, buyTradeDto);
+
+        // then
+        assertEquals(Account.INITIAL_BALANCE - (buyTradeDto.stockPrice() * buyTradeDto.stockCount()), account.getBalance());
+        verify(tradeReservationService, times(1)).save(any(TradeReservation.class));
+    }
+
+    @Test
+    @DisplayName("매도 예약 저장 테스트")
+    void handleReservationSaleTest() {
+        // given
+        given(holdingService.readByUserIdAndStockCode(1L, buyTradeDto.stockCode())).willReturn(Optional.of(holding));
+
+        // when
+        tradeReservationHandler.saveTradeReservation(1L, sellTradeDto);
 
         // then
         verify(tradeReservationService, times(1)).save(any(TradeReservation.class));


### PR DESCRIPTION
## 배경
- close #54 
- 매수/매도 로직 처리

## 작업 사항
- Holding Entity 구현
- 매수, 매도 과정 중 예외처리
- 관련 test 코드 작성

## 추가 논의
- `StockTradeExecutor.handleStockPurchase`에서 `Holding`을 가져올 때 `get()`을 통해 Optional을 가져오는 이유는 조건문을 통해 해당 주식이 존재하는지 확인했기 떄문입니다!
- 예약 주식 취소로직은 아직 구현되지 않았습니다!
- `StockTradeExecutor`, `StockTradeService`, `TradeReservationHandler`로직 상에서 같은 Account, Holding 여러번 호출하니 쿼리가 여러번 쿼리가 날아가는 문제가 있었습니다. '같은 트랜잭션이면 1차 캐시에 있기에 문제가 없는 것이 아닌가?'라는 생각을 가지고 인터넷을 찾아보니 다음의 [블로그](https://kimsy8979.tistory.com/41)를 보게 되었습니다. (참고가 될 수 있으니 가져와봤습니다!)
간단히 요약하면, pk값을 통한 조회는 1차 캐시에 저장이 되지만, 다른 네이밍 메서드는 JPQL로 동작하기에 1차 캐시에 올라가지 않아 계속해서 db에 접근하는 것이었습니다.
그래서, 강제로 1차캐시에 넣고 조회하는 로직 등 다양한 로직을 시도했지만, 저희의 코드는 결국에 pk를 이용하는 것이 아니기떄문에 문제를 해결하지 못했습니다.
이 부분에 대해서 인지해주셨으면 좋겠고, 좋은 방법 있다면 말씀해주세요! (매개변수로 조회한 값을 넘길 시, 사용하지 않는 값도 넘겨야 하는 문제)