### PR TITLE
Feature: 무분별한 계좌 개설 제한

### DIFF
--- a/src/main/java/muzusi/application/account/service/UserAccountService.java
+++ b/src/main/java/muzusi/application/account/service/UserAccountService.java
@@ -31,7 +31,7 @@ public class UserAccountService {
     public void connectNewAccount(Long userId) {
         LocalDateTime latestCreatedAt = accountService.readCreatedAt(userId);
 
-        if (latestCreatedAt.toLocalDate().equals(LocalDate.now())) {
+        if (latestCreatedAt != null && latestCreatedAt.toLocalDate().equals(LocalDate.now())) {
             throw new CustomException(AccountErrorType.ACCOUNT_CREATION_LIMIT);
         }
         User foundUser = userService.readById(userId)

--- a/src/main/java/muzusi/application/account/service/UserAccountService.java
+++ b/src/main/java/muzusi/application/account/service/UserAccountService.java
@@ -11,6 +11,8 @@ import muzusi.global.exception.CustomException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -27,6 +29,11 @@ public class UserAccountService {
      */
     @Transactional
     public void connectNewAccount(Long userId) {
+        LocalDateTime latestCreatedAt = accountService.readCreatedAt(userId);
+
+        if (latestCreatedAt.toLocalDate().equals(LocalDate.now())) {
+            throw new CustomException(AccountErrorType.ACCOUNT_CREATION_LIMIT);
+        }
         User foundUser = userService.readById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
 

--- a/src/main/java/muzusi/domain/account/exception/AccountErrorType.java
+++ b/src/main/java/muzusi/domain/account/exception/AccountErrorType.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AccountErrorType implements BaseErrorType {
     NOT_FOUND(HttpStatus.NOT_FOUND, "4001", "계좌가 존재하지 않습니다."),
-    INSUFFICIENT_BALANCE(HttpStatus.BAD_REQUEST, "4002", "계좌 잔액이 부족합니다.")
+    INSUFFICIENT_BALANCE(HttpStatus.BAD_REQUEST, "4002", "계좌 잔액이 부족합니다."),
+    ACCOUNT_CREATION_LIMIT(HttpStatus.BAD_REQUEST, "4003", "오늘은 이미 계좌를 생성했습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/muzusi/domain/account/repository/AccountRepository.java
+++ b/src/main/java/muzusi/domain/account/repository/AccountRepository.java
@@ -5,12 +5,20 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
     List<Account> findByUser_Id(Long userId);
 
-    @Query(value = "SELECT * FROM account a WHERE a.user_id = :userId ORDER BY a.created_at DESC LIMIT 1", nativeQuery = true)
+    @Query(value = "SELECT * FROM account a " +
+            "WHERE a.user_id = :userId " +
+            "ORDER BY a.created_at DESC LIMIT 1", nativeQuery = true)
     Optional<Account> findLatestAccount(@Param("userId") Long userId);
+
+    @Query(value = "SELECT a.created_at FROM account a " +
+            "WHERE a.user_id = :userId " +
+            "ORDER BY a.created_at DESC LIMIT 1", nativeQuery = true)
+    LocalDateTime findLatestCreatedAt(@Param("userId") Long userId);
 }

--- a/src/main/java/muzusi/domain/account/service/AccountService.java
+++ b/src/main/java/muzusi/domain/account/service/AccountService.java
@@ -5,6 +5,7 @@ import muzusi.domain.account.entity.Account;
 import muzusi.domain.account.repository.AccountRepository;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,5 +24,9 @@ public class AccountService {
 
     public Optional<Account> readByUserId(Long userId) {
         return accountRepository.findLatestAccount(userId);
+    }
+
+    public LocalDateTime readCreatedAt(Long userId) {
+        return accountRepository.findLatestCreatedAt(userId);
     }
 }

--- a/src/main/java/muzusi/presentation/account/api/AccountApi.java
+++ b/src/main/java/muzusi/presentation/account/api/AccountApi.java
@@ -27,6 +27,15 @@ public interface AccountApi {
                                             "message": "요청이 성공하였습니다."
                                         }
                                     """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "계좌 생성 횟수 제한",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": "4003",
+                                            "message": "오늘은 이미 계좌를 생성했습니다."
+                                        }
+                                    """)
                     }))
     })
     ResponseEntity<?> createNewAccount(@AuthenticationPrincipal CustomUserDetails userDetails);


### PR DESCRIPTION
## 배경
- 무분별한 계좌 개설로 인해 처리량의 복잡도가 발생. 하루에 1회 계좌 개설 가능

## 작업 사항
- 가장 최신 계좌 기준으로 날짜 확인 후 계좌 개설

## 추가 논의
- 현재는 하루에 1회로 제한하였지만, 계좌 개설 횟수 제한 날짜에 대해 다른 의견있다면 제시해주세요!
- `UserAccountService.connectNewAccount()`에서 최신 계좌의 날짜를 가져와 조건문을 통해 확인 하는 과정에서 `latestCreatedAt != null`가 있습니다. 서버의 로직상 최초 가입을 하면 계좌를 연동해주어 `null`체크를 안해줘도 되지만, 예외 상황이 발생할 수 있기에 추가하였습니다.

## 테스트
<img width="409" alt="스크린샷 2025-01-22 오후 3 45 51" src="https://github.com/user-attachments/assets/d1eef416-b766-4658-b250-531578b3623b" />

