### PR TITLE
Refact: News 로직 수정 및 Security Endpoint 허용

### DIFF
--- a/src/main/java/muzusi/application/news/dto/NewsInfoDto.java
+++ b/src/main/java/muzusi/application/news/dto/NewsInfoDto.java
@@ -5,6 +5,7 @@ import muzusi.domain.news.entity.News;
 import java.time.LocalDateTime;
 
 public record NewsInfoDto(
+        Long id,
         String title,
         String link,
         String keyword,
@@ -12,6 +13,7 @@ public record NewsInfoDto(
 ) {
     public static NewsInfoDto from(News news) {
         return new NewsInfoDto(
+                news.getId(),
                 news.getTitle(),
                 news.getLink(),
                 news.getKeyword(),

--- a/src/main/java/muzusi/application/news/service/NewsManagementService.java
+++ b/src/main/java/muzusi/application/news/service/NewsManagementService.java
@@ -27,7 +27,7 @@ public class NewsManagementService {
     public void createPostsFromNews() {
         keywords.forEach(keyword ->
                 newsApiClient.fetchNews(keyword).stream()
-                        .filter(content -> !newsService.existsByTitle(content.get("title")))
+                        .filter(content -> !newsService.existsByLink(content.get("link")))
                         .map(content ->
                                 News.builder()
                                         .title(content.get("title"))

--- a/src/main/java/muzusi/domain/news/repository/NewsRepository.java
+++ b/src/main/java/muzusi/domain/news/repository/NewsRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public interface NewsRepository extends JpaRepository<News, Long> {
     Page<News> findByKeyword(String keyword, Pageable pageable);
-    boolean existsByTitle(String title);
+    boolean existsByLink(String link);
 
     @Query("SELECT n.id FROM news n WHERE n.pubDate < :dateTime")
     List<Long> findIdsByPubDateBefore(@Param("dateTime") LocalDateTime dateTime);

--- a/src/main/java/muzusi/domain/news/service/NewsService.java
+++ b/src/main/java/muzusi/domain/news/service/NewsService.java
@@ -15,8 +15,8 @@ import java.util.List;
 public class NewsService {
     private final NewsRepository newsRepository;
 
-    public void save(News post) {
-        newsRepository.save(post);
+    public void save(News news) {
+        newsRepository.save(news);
     }
 
     public Page<News> readAll(Pageable pageable) {
@@ -31,8 +31,8 @@ public class NewsService {
         return newsRepository.findIdsByPubDateBefore(dateTime);
     }
 
-    public boolean existsByTitle(String title) {
-        return newsRepository.existsByTitle(title);
+    public boolean existsByLink(String link) {
+        return newsRepository.existsByLink(link);
     }
 
     public void deleteByIds(List<Long> ids) {

--- a/src/main/java/muzusi/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/muzusi/infrastructure/config/security/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
             "/swagger-resources/**", "/swagger-ui/**",
             "/v3/api-docs/**", "/webjars/**", "/error",
             "/auth/**", "/v1/api/link/checker/**", "/api-checker/**",
-            "/stocks/rank/**"
+            "/stocks/rank/**", "/news/**"
     };
 
     @Bean


### PR DESCRIPTION
## 배경
- News 중복성 Link를 통한 중복성 확인을 통해 안전성 높이고, 홈화면에서 보이는 뉴스는 로그인되기 전 상태도 보이니 엔드포인트 허용해야되는 상황

## 작업 사항
- News link 중복성 체크로 수정
- 엔드포인트 허용

## 추가 논의
x