### PR TITLE
Fix: 공휴일 간 주식 순위 저장 시 오류로 인한 변경

### DIFF
--- a/src/main/java/muzusi/infrastructure/kis/KisRankingClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisRankingClient.java
@@ -97,7 +97,7 @@ public class KisRankingClient {
                 .queryParam("fid_cond_scr_div_code","20170")
                 .queryParam("fid_input_iscd","0000")
                 .queryParam("fid_rank_sort_cls_code",fluctuation)
-                .queryParam("fid_input_cnt_1","1")
+                .queryParam("fid_input_cnt_1","0")
                 .queryParam("fid_prc_cls_code","1")
                 .queryParam("fid_input_price_1","")
                 .queryParam("fid_input_price_2","")

--- a/src/main/java/muzusi/infrastructure/kis/KisRankingClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisRankingClient.java
@@ -39,7 +39,7 @@ public class KisRankingClient {
                 .queryParam("FID_COND_MRKT_DIV_CODE", "J")
                 .queryParam("FID_COND_SCR_DIV_CODE", "20171")
                 .queryParam("FID_INPUT_ISCD", "0000")
-                .queryParam("FID_DIV_CLS_CODE", "2")
+                .queryParam("FID_DIV_CLS_CODE", "0")
                 .queryParam("FID_BLNG_CLS_CODE", "0")
                 .queryParam("FID_TRGT_CLS_CODE", "")
                 .queryParam("FID_TRGT_EXLS_CLS_CODE", "")


### PR DESCRIPTION
## 배경
- 주말 및 공휴일 간 등락률 순위 저장 시 이상하게 저장되는 경우 존재하여 이에 대한 수정 소요 발생
- 거래량 순위 조회 시 종목 변경 요청: 우선주 → 전체

## 작업 사항
- 등락률 순위 조회 시 조회 일수 변경 
   - 기존 `1일` → 변경 `전체`
- 거래량 순위 조회 종목 변경
   - 기존 `우선주` → 변경 `전체`