### PR TITLE
Feature: 주식 차트 기간별 조회 구현

### DIFF
--- a/src/main/java/muzusi/application/stock/dto/StockChartInfoDto.java
+++ b/src/main/java/muzusi/application/stock/dto/StockChartInfoDto.java
@@ -1,0 +1,52 @@
+package muzusi.application.stock.dto;
+
+import muzusi.domain.stock.entity.StockDaily;
+import muzusi.domain.stock.entity.StockMonthly;
+import muzusi.domain.stock.entity.StockWeekly;
+import muzusi.domain.stock.entity.StockYearly;
+
+public record StockChartInfoDto(
+        String stockCode,
+        String date,
+        Double open,
+        Double high,
+        Double low,
+        Double close,
+        Long volume
+) {
+    public static StockChartInfoDto from(StockDaily stockDaily) {
+        return new StockChartInfoDto(
+                stockDaily.getStockCode(), stockDaily.getDate(),
+                stockDaily.getOpen(), stockDaily.getHigh(),
+                stockDaily.getLow(), stockDaily.getClose(),
+                stockDaily.getVolume()
+        );
+    }
+
+    public static StockChartInfoDto from(StockWeekly stockWeekly) {
+        return new StockChartInfoDto(
+                stockWeekly.getStockCode(), stockWeekly.getDate(),
+                stockWeekly.getOpen(), stockWeekly.getHigh(),
+                stockWeekly.getLow(), stockWeekly.getClose(),
+                stockWeekly.getVolume()
+        );
+    }
+
+    public static StockChartInfoDto from(StockMonthly stockMonthly) {
+        return new StockChartInfoDto(
+                stockMonthly.getStockCode(), stockMonthly.getDate(),
+                stockMonthly.getOpen(), stockMonthly.getHigh(),
+                stockMonthly.getLow(), stockMonthly.getClose(),
+                stockMonthly.getVolume()
+        );
+    }
+
+    public static StockChartInfoDto from(StockYearly stockYearly) {
+        return new StockChartInfoDto(
+                stockYearly.getStockCode(), stockYearly.getDate(),
+                stockYearly.getOpen(), stockYearly.getHigh(),
+                stockYearly.getLow(), stockYearly.getClose(),
+                stockYearly.getVolume()
+        );
+    }
+}

--- a/src/main/java/muzusi/application/stock/dto/StockChartInfoDto.java
+++ b/src/main/java/muzusi/application/stock/dto/StockChartInfoDto.java
@@ -5,9 +5,11 @@ import muzusi.domain.stock.entity.StockMonthly;
 import muzusi.domain.stock.entity.StockWeekly;
 import muzusi.domain.stock.entity.StockYearly;
 
+import java.time.LocalDate;
+
 public record StockChartInfoDto(
         String stockCode,
-        String date,
+        LocalDate date,
         Double open,
         Double high,
         Double low,

--- a/src/main/java/muzusi/application/stock/service/StockHistoryService.java
+++ b/src/main/java/muzusi/application/stock/service/StockHistoryService.java
@@ -1,0 +1,34 @@
+package muzusi.application.stock.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.stock.dto.StockChartInfoDto;
+import muzusi.domain.stock.service.StockDailyService;
+import muzusi.domain.stock.service.StockMonthlyService;
+import muzusi.domain.stock.service.StockWeeklyService;
+import muzusi.domain.stock.service.StockYearlyService;
+import muzusi.domain.stock.type.StockPeriodType;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StockHistoryService {
+    private final StockDailyService stockDailyService;
+    private final StockWeeklyService stockWeeklyService;
+    private final StockMonthlyService stockMonthlyService;
+    private final StockYearlyService stockYearlyService;
+
+    public List<StockChartInfoDto> getStockHistoryByType(String stockCode, StockPeriodType stockPeriodType) {
+        return switch (stockPeriodType) {
+            case DAILY -> stockDailyService.readByStockCode(stockCode)
+                    .stream().map(StockChartInfoDto::from).toList();
+            case WEEKLY -> stockWeeklyService.readByStockCode(stockCode)
+                    .stream().map(StockChartInfoDto::from).toList();
+            case MONTHLY -> stockMonthlyService.readByStockCode(stockCode)
+                    .stream().map(StockChartInfoDto::from).toList();
+            case YEARLY -> stockYearlyService.readByStockCode(stockCode)
+                    .stream().map(StockChartInfoDto::from).toList();
+        };
+    }
+}

--- a/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
+++ b/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
@@ -1,7 +1,7 @@
 package muzusi.application.trade.service;
 
 import lombok.RequiredArgsConstructor;
-import muzusi.application.stock.service.StockService;
+import muzusi.domain.stock.service.StockService;
 import muzusi.application.trade.dto.TradeReqDto;
 import muzusi.domain.account.entity.Account;
 import muzusi.domain.account.exception.AccountErrorType;

--- a/src/main/java/muzusi/domain/stock/entity/StockDaily.java
+++ b/src/main/java/muzusi/domain/stock/entity/StockDaily.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.LocalDate;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document(collection = "stock_daily")
@@ -16,7 +18,7 @@ public class StockDaily {
 
     private String stockCode;
 
-    private String date;
+    private LocalDate date;
 
     private Double open;
 
@@ -29,7 +31,7 @@ public class StockDaily {
     private Long volume;
 
     @Builder
-    public StockDaily(String stockCode, String date, Double open, Double high, Double low, Double close, Long volume) {
+    public StockDaily(String stockCode, LocalDate date, Double open, Double high, Double low, Double close, Long volume) {
         this.stockCode = stockCode;
         this.date = date;
         this.open = open;

--- a/src/main/java/muzusi/domain/stock/entity/StockDaily.java
+++ b/src/main/java/muzusi/domain/stock/entity/StockDaily.java
@@ -1,0 +1,41 @@
+package muzusi.domain.stock.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "stock_daily")
+public class StockDaily {
+    @Id
+    private String id;
+
+    private String stockCode;
+
+    private String date;
+
+    private Double open;
+
+    private Double high;
+
+    private Double low;
+
+    private Double close;
+
+    private Long volume;
+
+    @Builder
+    public StockDaily(String stockCode, String date, Double open, Double high, Double low, Double close, Long volume) {
+        this.stockCode = stockCode;
+        this.date = date;
+        this.open = open;
+        this.high = high;
+        this.low = low;
+        this.close = close;
+        this.volume = volume;
+    }
+}

--- a/src/main/java/muzusi/domain/stock/entity/StockMonthly.java
+++ b/src/main/java/muzusi/domain/stock/entity/StockMonthly.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.LocalDate;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document(collection = "stock_monthly")
@@ -16,7 +18,7 @@ public class StockMonthly {
 
     private String stockCode;
 
-    private String date;
+    private LocalDate date;
 
     private Double open;
 
@@ -29,7 +31,7 @@ public class StockMonthly {
     private Long volume;
 
     @Builder
-    public StockMonthly(String stockCode, String date, Double open, Double high, Double low, Double close, Long volume) {
+    public StockMonthly(String stockCode, LocalDate date, Double open, Double high, Double low, Double close, Long volume) {
         this.stockCode = stockCode;
         this.date = date;
         this.open = open;

--- a/src/main/java/muzusi/domain/stock/entity/StockMonthly.java
+++ b/src/main/java/muzusi/domain/stock/entity/StockMonthly.java
@@ -1,0 +1,41 @@
+package muzusi.domain.stock.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "stock_monthly")
+public class StockMonthly {
+    @Id
+    private String id;
+
+    private String stockCode;
+
+    private String date;
+
+    private Double open;
+
+    private Double high;
+
+    private Double low;
+
+    private Double close;
+
+    private Long volume;
+
+    @Builder
+    public StockMonthly(String stockCode, String date, Double open, Double high, Double low, Double close, Long volume) {
+        this.stockCode = stockCode;
+        this.date = date;
+        this.open = open;
+        this.high = high;
+        this.low = low;
+        this.close = close;
+        this.volume = volume;
+    }
+}

--- a/src/main/java/muzusi/domain/stock/entity/StockWeekly.java
+++ b/src/main/java/muzusi/domain/stock/entity/StockWeekly.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.LocalDate;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document(collection = "stock_weekly")
@@ -16,7 +18,7 @@ public class StockWeekly {
 
     private String stockCode;
 
-    private String date;
+    private LocalDate date;
 
     private Double open;
 
@@ -29,7 +31,7 @@ public class StockWeekly {
     private Long volume;
 
     @Builder
-    public StockWeekly(String stockCode, String date, Double open, Double high, Double low, Double close, Long volume) {
+    public StockWeekly(String stockCode, LocalDate date, Double open, Double high, Double low, Double close, Long volume) {
         this.stockCode = stockCode;
         this.date = date;
         this.open = open;

--- a/src/main/java/muzusi/domain/stock/entity/StockWeekly.java
+++ b/src/main/java/muzusi/domain/stock/entity/StockWeekly.java
@@ -1,0 +1,41 @@
+package muzusi.domain.stock.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "stock_weekly")
+public class StockWeekly {
+    @Id
+    private String id;
+
+    private String stockCode;
+
+    private String date;
+
+    private Double open;
+
+    private Double high;
+
+    private Double low;
+
+    private Double close;
+
+    private Long volume;
+
+    @Builder
+    public StockWeekly(String stockCode, String date, Double open, Double high, Double low, Double close, Long volume) {
+        this.stockCode = stockCode;
+        this.date = date;
+        this.open = open;
+        this.high = high;
+        this.low = low;
+        this.close = close;
+        this.volume = volume;
+    }
+}

--- a/src/main/java/muzusi/domain/stock/entity/StockYearly.java
+++ b/src/main/java/muzusi/domain/stock/entity/StockYearly.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.LocalDate;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document(collection = "stock_yearly")
@@ -16,7 +18,7 @@ public class StockYearly {
 
     private String stockCode;
 
-    private String date;
+    private LocalDate date;
 
     private Double open;
 
@@ -29,7 +31,7 @@ public class StockYearly {
     private Long volume;
 
     @Builder
-    public StockYearly(String stockCode, String date, Double open, Double high, Double low, Double close, Long volume) {
+    public StockYearly(String stockCode, LocalDate date, Double open, Double high, Double low, Double close, Long volume) {
         this.stockCode = stockCode;
         this.date = date;
         this.open = open;

--- a/src/main/java/muzusi/domain/stock/entity/StockYearly.java
+++ b/src/main/java/muzusi/domain/stock/entity/StockYearly.java
@@ -1,0 +1,41 @@
+package muzusi.domain.stock.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "stock_yearly")
+public class StockYearly {
+    @Id
+    private String id;
+
+    private String stockCode;
+
+    private String date;
+
+    private Double open;
+
+    private Double high;
+
+    private Double low;
+
+    private Double close;
+
+    private Long volume;
+
+    @Builder
+    public StockYearly(String stockCode, String date, Double open, Double high, Double low, Double close, Long volume) {
+        this.stockCode = stockCode;
+        this.date = date;
+        this.open = open;
+        this.high = high;
+        this.low = low;
+        this.close = close;
+        this.volume = volume;
+    }
+}

--- a/src/main/java/muzusi/domain/stock/repository/StockDailyRepository.java
+++ b/src/main/java/muzusi/domain/stock/repository/StockDailyRepository.java
@@ -1,0 +1,10 @@
+package muzusi.domain.stock.repository;
+
+import muzusi.domain.stock.entity.StockDaily;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface StockDailyRepository extends MongoRepository<StockDaily, String> {
+    List<StockDaily> findByStockCode(String stockCode);
+}

--- a/src/main/java/muzusi/domain/stock/repository/StockDailyRepository.java
+++ b/src/main/java/muzusi/domain/stock/repository/StockDailyRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import java.util.List;
 
 public interface StockDailyRepository extends MongoRepository<StockDaily, String> {
-    List<StockDaily> findByStockCode(String stockCode);
+    List<StockDaily> findByStockCodeOrderByDateAsc(String stockCode);
 }

--- a/src/main/java/muzusi/domain/stock/repository/StockMonthlyRepository.java
+++ b/src/main/java/muzusi/domain/stock/repository/StockMonthlyRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import java.util.List;
 
 public interface StockMonthlyRepository extends MongoRepository<StockMonthly, String> {
-    List<StockMonthly> findByStockCode(String stockCode);
+    List<StockMonthly> findByStockCodeOrderByDateAsc(String stockCode);
 }

--- a/src/main/java/muzusi/domain/stock/repository/StockMonthlyRepository.java
+++ b/src/main/java/muzusi/domain/stock/repository/StockMonthlyRepository.java
@@ -1,0 +1,10 @@
+package muzusi.domain.stock.repository;
+
+import muzusi.domain.stock.entity.StockMonthly;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface StockMonthlyRepository extends MongoRepository<StockMonthly, String> {
+    List<StockMonthly> findByStockCode(String stockCode);
+}

--- a/src/main/java/muzusi/domain/stock/repository/StockWeeklyRepository.java
+++ b/src/main/java/muzusi/domain/stock/repository/StockWeeklyRepository.java
@@ -1,0 +1,10 @@
+package muzusi.domain.stock.repository;
+
+import muzusi.domain.stock.entity.StockWeekly;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface StockWeeklyRepository extends MongoRepository<StockWeekly, String> {
+    List<StockWeekly> findByStockCode(String stockCode);
+}

--- a/src/main/java/muzusi/domain/stock/repository/StockWeeklyRepository.java
+++ b/src/main/java/muzusi/domain/stock/repository/StockWeeklyRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import java.util.List;
 
 public interface StockWeeklyRepository extends MongoRepository<StockWeekly, String> {
-    List<StockWeekly> findByStockCode(String stockCode);
+    List<StockWeekly> findByStockCodeOrderByDateAsc(String stockCode);
 }

--- a/src/main/java/muzusi/domain/stock/repository/StockYearlyRepository.java
+++ b/src/main/java/muzusi/domain/stock/repository/StockYearlyRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import java.util.List;
 
 public interface StockYearlyRepository extends MongoRepository<StockYearly, String> {
-    List<StockYearly> findByStockCode(String stockCode);
+    List<StockYearly> findByStockCodeOrderByDateAsc(String stockCode);
 }

--- a/src/main/java/muzusi/domain/stock/repository/StockYearlyRepository.java
+++ b/src/main/java/muzusi/domain/stock/repository/StockYearlyRepository.java
@@ -1,0 +1,10 @@
+package muzusi.domain.stock.repository;
+
+import muzusi.domain.stock.entity.StockYearly;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface StockYearlyRepository extends MongoRepository<StockYearly, String> {
+    List<StockYearly> findByStockCode(String stockCode);
+}

--- a/src/main/java/muzusi/domain/stock/service/StockDailyService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockDailyService.java
@@ -1,0 +1,21 @@
+package muzusi.domain.stock.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.stock.entity.StockDaily;
+import muzusi.domain.stock.repository.StockDailyRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StockDailyService {
+    private final StockDailyRepository stockDailyRepository;
+
+    public void save(StockDaily stockDaily) {
+        stockDailyRepository.save(stockDaily);
+    }
+    public List<StockDaily> readByStockCode(String stockCode) {
+        return stockDailyRepository.findByStockCode(stockCode);
+    }
+}

--- a/src/main/java/muzusi/domain/stock/service/StockDailyService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockDailyService.java
@@ -16,10 +16,6 @@ public class StockDailyService {
         stockDailyRepository.save(stockDaily);
     }
 
-    public void saveAll(List<StockDaily> stockDailies) {
-        stockDailyRepository.saveAll(stockDailies);
-    }
-
     public List<StockDaily> readByStockCode(String stockCode) {
         return stockDailyRepository.findByStockCodeOrderByDateAsc(stockCode);
     }

--- a/src/main/java/muzusi/domain/stock/service/StockDailyService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockDailyService.java
@@ -15,7 +15,12 @@ public class StockDailyService {
     public void save(StockDaily stockDaily) {
         stockDailyRepository.save(stockDaily);
     }
+
+    public void saveAll(List<StockDaily> stockDailies) {
+        stockDailyRepository.saveAll(stockDailies);
+    }
+
     public List<StockDaily> readByStockCode(String stockCode) {
-        return stockDailyRepository.findByStockCode(stockCode);
+        return stockDailyRepository.findByStockCodeOrderByDateAsc(stockCode);
     }
 }

--- a/src/main/java/muzusi/domain/stock/service/StockMonthlyService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockMonthlyService.java
@@ -17,6 +17,6 @@ public class StockMonthlyService {
     }
 
     public List<StockMonthly> readByStockCode(String stockCode) {
-        return stockMonthlyRepository.findByStockCode(stockCode);
+        return stockMonthlyRepository.findByStockCodeOrderByDateAsc(stockCode);
     }
 }

--- a/src/main/java/muzusi/domain/stock/service/StockMonthlyService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockMonthlyService.java
@@ -1,0 +1,22 @@
+package muzusi.domain.stock.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.stock.entity.StockMonthly;
+import muzusi.domain.stock.repository.StockMonthlyRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StockMonthlyService {
+    private final StockMonthlyRepository stockMonthlyRepository;
+
+    public void save(StockMonthly stockMonthly) {
+        stockMonthlyRepository.save(stockMonthly);
+    }
+
+    public List<StockMonthly> readByStockCode(String stockCode) {
+        return stockMonthlyRepository.findByStockCode(stockCode);
+    }
+}

--- a/src/main/java/muzusi/domain/stock/service/StockService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockService.java
@@ -1,4 +1,4 @@
-package muzusi.application.stock.service;
+package muzusi.domain.stock.service;
 
 import lombok.RequiredArgsConstructor;
 import muzusi.domain.stock.entity.Stock;

--- a/src/main/java/muzusi/domain/stock/service/StockWeeklyService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockWeeklyService.java
@@ -17,6 +17,6 @@ public class StockWeeklyService {
     }
 
     public List<StockWeekly> readByStockCode(String stockCode) {
-        return stockWeeklyRepository.findByStockCode(stockCode);
+        return stockWeeklyRepository.findByStockCodeOrderByDateAsc(stockCode);
     }
 }

--- a/src/main/java/muzusi/domain/stock/service/StockWeeklyService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockWeeklyService.java
@@ -1,0 +1,22 @@
+package muzusi.domain.stock.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.stock.entity.StockWeekly;
+import muzusi.domain.stock.repository.StockWeeklyRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StockWeeklyService {
+    private final StockWeeklyRepository stockWeeklyRepository;
+
+    public void save(StockWeekly stockWeekly) {
+        stockWeeklyRepository.save(stockWeekly);
+    }
+
+    public List<StockWeekly> readByStockCode(String stockCode) {
+        return stockWeeklyRepository.findByStockCode(stockCode);
+    }
+}

--- a/src/main/java/muzusi/domain/stock/service/StockYearlyService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockYearlyService.java
@@ -1,0 +1,22 @@
+package muzusi.domain.stock.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.stock.entity.StockYearly;
+import muzusi.domain.stock.repository.StockYearlyRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StockYearlyService {
+    private final StockYearlyRepository stockYearlyRepository;
+
+    public void save(StockYearly stockYearly) {
+        stockYearlyRepository.save(stockYearly);
+    }
+
+    public List<StockYearly> readByStockCode(String stockCode) {
+        return stockYearlyRepository.findByStockCode(stockCode);
+    }
+}

--- a/src/main/java/muzusi/domain/stock/service/StockYearlyService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockYearlyService.java
@@ -16,7 +16,11 @@ public class StockYearlyService {
         stockYearlyRepository.save(stockYearly);
     }
 
+    public void saveAll(List<StockYearly> stockYearlies) {
+        stockYearlyRepository.saveAll(stockYearlies);
+    }
+
     public List<StockYearly> readByStockCode(String stockCode) {
-        return stockYearlyRepository.findByStockCode(stockCode);
+        return stockYearlyRepository.findByStockCodeOrderByDateAsc(stockCode);
     }
 }

--- a/src/main/java/muzusi/domain/stock/service/StockYearlyService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockYearlyService.java
@@ -16,10 +16,6 @@ public class StockYearlyService {
         stockYearlyRepository.save(stockYearly);
     }
 
-    public void saveAll(List<StockYearly> stockYearlies) {
-        stockYearlyRepository.saveAll(stockYearlies);
-    }
-
     public List<StockYearly> readByStockCode(String stockCode) {
         return stockYearlyRepository.findByStockCodeOrderByDateAsc(stockCode);
     }

--- a/src/main/java/muzusi/domain/stock/type/StockPeriodType.java
+++ b/src/main/java/muzusi/domain/stock/type/StockPeriodType.java
@@ -1,0 +1,5 @@
+package muzusi.domain.stock.type;
+
+public enum StockPeriodType {
+    DAILY, WEEKLY, MONTHLY, YEARLY
+}

--- a/src/main/java/muzusi/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/muzusi/infrastructure/config/security/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
             "/swagger-resources/**", "/swagger-ui/**",
             "/v3/api-docs/**", "/webjars/**", "/error",
             "/auth/**", "/v1/api/link/checker/**", "/api-checker/**",
-            "/stocks/rank/**", "/news/**"
+            "/stocks/**", "/news/**"
     };
 
     @Bean

--- a/src/main/java/muzusi/presentation/stock/api/StockHistoryApi.java
+++ b/src/main/java/muzusi/presentation/stock/api/StockHistoryApi.java
@@ -1,0 +1,64 @@
+package muzusi.presentation.stock.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import muzusi.domain.stock.type.StockPeriodType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@ApiGroup(value = "[주식 차트 조회 API]")
+@Tag(name = "[주식 차트 조회 API]", description = "주식 차트 조회 관련 API")
+public interface StockHistoryApi {
+
+    @TrackApi(description = "주식 차트 조회")
+    @Operation(summary = "주식 차트 조회", description = "주식 차트를 조회하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주식 차트 조회 성공(일/주/월/년 응답값 필드 동일)",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": [
+                                                {
+                                                     "stockCode": "005930",
+                                                     "date": "2024-08-27",
+                                                     "open": 75700.0,
+                                                     "high": 76500.0,
+                                                     "low": 75600.0,
+                                                     "close": 75800.0,
+                                                     "volume": 11130145
+                                                },
+                                                {
+                                                      "stockCode": "005930",
+                                                       "date": "2024-08-28",
+                                                      "open": 75800.0,
+                                                      "high": 76400.0,
+                                                      "low": 75400.0,
+                                                      "close": 76400.0,
+                                                      "volume": 9794514
+                                                },
+                                                {
+                                                      "stockCode": "005930",
+                                                      "date": "2024-08-29",
+                                                       "open": 73600.0,
+                                                       "high": 74700.0,
+                                                       "low": 73500.0,
+                                                       "close": 74000.0,
+                                                       "volume": 16884479
+                                                }
+                                            ]
+                                        }
+                                """)
+                    }))
+    })
+    ResponseEntity<?> getStockHistory(@PathVariable String stockCode,
+                                      @RequestParam StockPeriodType period);
+}

--- a/src/main/java/muzusi/presentation/stock/controller/StockHistoryController.java
+++ b/src/main/java/muzusi/presentation/stock/controller/StockHistoryController.java
@@ -1,0 +1,28 @@
+package muzusi.presentation.stock.controller;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.stock.service.StockHistoryService;
+import muzusi.domain.stock.type.StockPeriodType;
+import muzusi.global.response.success.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/stocks")
+@RequiredArgsConstructor
+public class StockHistoryController {
+    private final StockHistoryService stockHistoryService;
+
+    @GetMapping("/{stockCode}")
+    public ResponseEntity<?> read(@PathVariable String stockCode,
+                                  @RequestParam StockPeriodType period) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(stockHistoryService.getStockHistoryByType(stockCode, period))
+        );
+    }
+
+}

--- a/src/main/java/muzusi/presentation/stock/controller/StockHistoryController.java
+++ b/src/main/java/muzusi/presentation/stock/controller/StockHistoryController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import muzusi.application.stock.service.StockHistoryService;
 import muzusi.domain.stock.type.StockPeriodType;
 import muzusi.global.response.success.SuccessResponse;
+import muzusi.presentation.stock.api.StockHistoryApi;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,12 +15,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/stocks")
 @RequiredArgsConstructor
-public class StockHistoryController {
+public class StockHistoryController implements StockHistoryApi {
     private final StockHistoryService stockHistoryService;
 
+    @Override
     @GetMapping("/{stockCode}")
-    public ResponseEntity<?> read(@PathVariable String stockCode,
-                                  @RequestParam StockPeriodType period) {
+    public ResponseEntity<?> getStockHistory(@PathVariable String stockCode,
+                                             @RequestParam StockPeriodType period) {
         return ResponseEntity.ok(
                 SuccessResponse.from(stockHistoryService.getStockHistoryByType(stockCode, period))
         );

--- a/src/test/java/muzusi/application/trade/service/StockTradeExecutorTest.java
+++ b/src/test/java/muzusi/application/trade/service/StockTradeExecutorTest.java
@@ -1,6 +1,6 @@
 package muzusi.application.trade.service;
 
-import muzusi.application.stock.service.StockService;
+import muzusi.domain.stock.service.StockService;
 import muzusi.application.trade.dto.TradeReqDto;
 import muzusi.domain.account.entity.Account;
 import muzusi.domain.account.exception.AccountErrorType;


### PR DESCRIPTION
## 배경
- 일/월/주/년 별 주식 차트 데이터 조회의 필요성

## 작업 사항
- 각 기간별 몽고디비 컬렉션 생성
- 조회 로직 생성

## 추가 논의
x

## 테스트
데이터가 많다보니 조회 중 성능 개선을 위해 몽고 DB에 index를 추가하였습니다.

1. 인덱스 적용 전 (112ms)
![image](https://github.com/user-attachments/assets/7f3edcf7-97bd-4d54-8be3-d5236e9eb87c)

2. 인덱스 적용 후 (25ms)
![image](https://github.com/user-attachments/assets/7663a13f-92e6-413f-9ce2-e0203aee154b)

