### PR TITLE
Feature: 주식 순위 갱신 시간 저장

### DIFF
--- a/src/main/java/muzusi/application/kis/dto/KisDto.java
+++ b/src/main/java/muzusi/application/kis/dto/KisDto.java
@@ -1,0 +1,29 @@
+package muzusi.application.kis.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class KisDto {
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    public static class Time {
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        private LocalDateTime value;
+
+        public static Time of(LocalDateTime time) {
+            return new Time(time);
+        }
+    }
+}

--- a/src/main/java/muzusi/application/kis/service/KisRankingService.java
+++ b/src/main/java/muzusi/application/kis/service/KisRankingService.java
@@ -1,13 +1,16 @@
 package muzusi.application.kis.service;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import muzusi.application.kis.dto.KisDto;
 import muzusi.application.stock.dto.RankStockDto;
 import muzusi.global.redis.RedisService;
 import muzusi.infrastructure.kis.KisConstant;
 import muzusi.infrastructure.kis.KisRankingClient;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -17,6 +20,12 @@ public class KisRankingService {
     private final KisRankingClient kisRankingClient;
     private final RedisService redisService;
 
+    @PostConstruct
+    public void init() {
+        this.saveVolumeRank();
+        this.saveFluctuationRank();
+    }
+
     public void saveVolumeRank() {
         List<RankStockDto> rankStockDtos = kisRankingClient.getVolumeRank();
 
@@ -25,6 +34,8 @@ public class KisRankingService {
         for (RankStockDto rankStockDto : rankStockDtos) {
             redisService.setList(KisConstant.VOLUME_RANK_PREFIX.getValue(), rankStockDto);
         }
+
+        redisService.set(KisConstant.VOLUME_RANK_TIME_PREFIX.getValue(), KisDto.Time.of(LocalDateTime.now()));
     }
 
     public void saveFluctuationRank() {
@@ -41,5 +52,7 @@ public class KisRankingService {
         for (RankStockDto fallingRankStock : fallingRankStocks) {
             redisService.setList(KisConstant.FALLING_RANK_PREFIX.getValue(), fallingRankStock);
         }
+
+        redisService.set(KisConstant.FLUCTUATION_RANK_TIME_PREFIX.getValue(), KisDto.Time.of(LocalDateTime.now()));
     }
 }

--- a/src/main/java/muzusi/application/kis/service/KisRankingService.java
+++ b/src/main/java/muzusi/application/kis/service/KisRankingService.java
@@ -1,6 +1,5 @@
 package muzusi.application.kis.service;
 
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import muzusi.application.kis.dto.KisDto;

--- a/src/main/java/muzusi/application/kis/service/KisRankingService.java
+++ b/src/main/java/muzusi/application/kis/service/KisRankingService.java
@@ -20,12 +20,6 @@ public class KisRankingService {
     private final KisRankingClient kisRankingClient;
     private final RedisService redisService;
 
-    @PostConstruct
-    public void init() {
-        this.saveVolumeRank();
-        this.saveFluctuationRank();
-    }
-
     public void saveVolumeRank() {
         List<RankStockDto> rankStockDtos = kisRankingClient.getVolumeRank();
 

--- a/src/main/java/muzusi/application/stock/service/StockRankingService.java
+++ b/src/main/java/muzusi/application/stock/service/StockRankingService.java
@@ -1,28 +1,34 @@
 package muzusi.application.stock.service;
 
 import lombok.RequiredArgsConstructor;
+import muzusi.application.kis.dto.KisDto;
 import muzusi.application.stock.dto.RankStockDto;
 import muzusi.domain.stock.type.StockRankingType;
 import muzusi.global.redis.RedisService;
 import muzusi.infrastructure.kis.KisConstant;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class StockRankingService {
     private final RedisService redisService;
 
-    public List<RankStockDto> getStockRanking(StockRankingType stockRankingType) {
+    public Map<String, Object> getStockRanking(StockRankingType stockRankingType) {
         return switch (stockRankingType) {
-            case RISING -> getStockRankingByType(KisConstant.RISING_RANK_PREFIX);
-            case FALLING -> getStockRankingByType(KisConstant.FALLING_RANK_PREFIX);
-            case VOLUME -> getStockRankingByType(KisConstant.VOLUME_RANK_PREFIX);
+            case RISING -> getStockRankingByType(KisConstant.RISING_RANK_PREFIX, KisConstant.FLUCTUATION_RANK_TIME_PREFIX);
+            case FALLING -> getStockRankingByType(KisConstant.FALLING_RANK_PREFIX, KisConstant.FLUCTUATION_RANK_TIME_PREFIX);
+            case VOLUME -> getStockRankingByType(KisConstant.VOLUME_RANK_PREFIX, KisConstant.VOLUME_RANK_TIME_PREFIX);
         };
     }
 
-    private List<RankStockDto> getStockRankingByType(KisConstant kisConstant) {
-        return redisService.getList(kisConstant.getValue()).stream().map(obj -> (RankStockDto) obj).toList();
+    private Map<String, Object> getStockRankingByType(KisConstant rank, KisConstant time) {
+        Map<String, Object> content = new HashMap<>();
+        content.put("time", ((KisDto.Time) redisService.get(time.getValue())).getValue().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        content.put("rank", redisService.getList(rank.getValue()).stream().map(obj -> (RankStockDto) obj).toList());
+        return content;
     }
 }

--- a/src/main/java/muzusi/global/redis/RedisService.java
+++ b/src/main/java/muzusi/global/redis/RedisService.java
@@ -20,6 +20,10 @@ public class RedisService {
         return redisTemplate.opsForList().range(key, 0 , -1);
     }
 
+    public void set(String key, Object value) {
+        redisTemplate.opsForValue().set(key, value);
+    }
+
     public void set(String key, Object value, Duration duration) {
         redisTemplate.opsForValue().set(key, value, duration);
     }

--- a/src/main/java/muzusi/infrastructure/kis/KisConstant.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisConstant.java
@@ -11,6 +11,8 @@ public enum KisConstant {
     VOLUME_RANK_PREFIX("kis:volume-rank"),
     RISING_RANK_PREFIX("kis:rising-rank"),
     FALLING_RANK_PREFIX("kis:falling-rank"),
+    VOLUME_RANK_TIME_PREFIX("kis:volume-rank-time"),
+    FLUCTUATION_RANK_TIME_PREFIX("kis:fluctuation-rank-time"),
     ;
 
     private final String value;

--- a/src/main/java/muzusi/presentation/stock/api/StockRankingApi.java
+++ b/src/main/java/muzusi/presentation/stock/api/StockRankingApi.java
@@ -20,282 +20,285 @@ public interface StockRankingApi {
     @Operation(summary = "주식 순위 조회", description = "주식 순위를 조회하는 API입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "주식 순위 조회 성공(급상승/급하락/거래량 응답값 필드 동일)",
-                    content = @Content(mediaType = "application/json", examples = {
+                    content = @Content(examples = {
                             @ExampleObject(value = """
                                     {
                                             "code": 200,
                                             "message": "요청이 성공하였습니다.",
                                             "data": [
-                                                {
-                                                    "name": "대원전선우",
-                                                    "code": "006345",
-                                                    "rank": 1,
-                                                    "price": 4925,
-                                                    "prdyVrss": 260,
-                                                    "prdyCtrt": 5.57,
-                                                    "avrgVol": 1205145
-                                                },
-                                                {
-                                                    "name": "삼성전자우",
-                                                    "code": "005935",
-                                                    "rank": 2,
-                                                    "price": 44000,
-                                                    "prdyVrss": 250,
-                                                    "prdyCtrt": 0.57,
-                                                    "avrgVol": 875275
-                                                },
-                                                {
-                                                    "name": "솔루스첨단소재2우B",
-                                                    "code": "33637L",
-                                                    "rank": 3,
-                                                    "price": 5320,
-                                                    "prdyVrss": -340,
-                                                    "prdyCtrt": -6.01,
-                                                    "avrgVol": 381572
-                                                },
-                                                {
-                                                    "name": "솔루스첨단소재1우",
-                                                    "code": "33637K",
-                                                    "rank": 4,
-                                                    "price": 2260,
-                                                    "prdyVrss": -65,
-                                                    "prdyCtrt": -2.8,
-                                                    "avrgVol": 344969
-                                                },
-                                                {
-                                                    "name": "미래에셋증권2우B",
-                                                    "code": "00680K",
-                                                    "rank": 5,
-                                                    "price": 3950,
-                                                    "prdyVrss": 15,
-                                                    "prdyCtrt": 0.38,
-                                                    "avrgVol": 93184
-                                                },
-                                                {
-                                                    "name": "대신증권우",
-                                                    "code": "003545",
-                                                    "rank": 6,
-                                                    "price": 15670,
-                                                    "prdyVrss": 100,
-                                                    "prdyCtrt": 0.64,
-                                                    "avrgVol": 63402
-                                                },
-                                                {
-                                                    "name": "대신증권2우B",
-                                                    "code": "003547",
-                                                    "rank": 7,
-                                                    "price": 14860,
-                                                    "prdyVrss": 50,
-                                                    "prdyCtrt": 0.34,
-                                                    "avrgVol": 58392
-                                                },
-                                                {
-                                                    "name": "NH투자증권우",
-                                                    "code": "005945",
-                                                    "rank": 8,
-                                                    "price": 12520,
-                                                    "prdyVrss": 60,
-                                                    "prdyCtrt": 0.48,
-                                                    "avrgVol": 52088
-                                                },
-                                                {
-                                                    "name": "현대차2우B",
-                                                    "code": "005387",
-                                                    "rank": 9,
-                                                    "price": 159600,
-                                                    "prdyVrss": -1200,
-                                                    "prdyCtrt": -0.75,
-                                                    "avrgVol": 45771
-                                                },
-                                                {
-                                                    "name": "두산우",
-                                                    "code": "000155",
-                                                    "rank": 10,
-                                                    "price": 142300,
-                                                    "prdyVrss": 10700,
-                                                    "prdyCtrt": 8.13,
-                                                    "avrgVol": 44698
-                                                },
-                                                {
-                                                    "name": "현대차우",
-                                                    "code": "005385",
-                                                    "rank": 11,
-                                                    "price": 154800,
-                                                    "prdyVrss": 400,
-                                                    "prdyCtrt": 0.26,
-                                                    "avrgVol": 37568
-                                                },
-                                                {
-                                                    "name": "미래에셋증권우",
-                                                    "code": "006805",
-                                                    "rank": 12,
-                                                    "price": 4385,
-                                                    "prdyVrss": 35,
-                                                    "prdyCtrt": 0.8,
-                                                    "avrgVol": 32734
-                                                },
-                                                {
-                                                    "name": "금호석유우",
-                                                    "code": "011785",
-                                                    "rank": 13,
-                                                    "price": 52000,
-                                                    "prdyVrss": 3500,
-                                                    "prdyCtrt": 7.22,
-                                                    "avrgVol": 31816
-                                                },
-                                                {
-                                                    "name": "LG전자우",
-                                                    "code": "066575",
-                                                    "rank": 14,
-                                                    "price": 40200,
-                                                    "prdyVrss": -200,
-                                                    "prdyCtrt": -0.5,
-                                                    "avrgVol": 27920
-                                                },
-                                                {
-                                                    "name": "코오롱모빌리티그룹우",
-                                                    "code": "45014K",
-                                                    "rank": 15,
-                                                    "price": 6410,
-                                                    "prdyVrss": 0,
-                                                    "prdyCtrt": 0.0,
-                                                    "avrgVol": 24223
-                                                },
-                                                {
-                                                    "name": "한화투자증권우",
-                                                    "code": "003535",
-                                                    "rank": 16,
-                                                    "price": 7040,
-                                                    "prdyVrss": 90,
-                                                    "prdyCtrt": 1.29,
-                                                    "avrgVol": 23764
-                                                },
-                                                {
-                                                    "name": "LG화학우",
-                                                    "code": "051915",
-                                                    "rank": 17,
-                                                    "price": 153500,
-                                                    "prdyVrss": -5600,
-                                                    "prdyCtrt": -3.52,
-                                                    "avrgVol": 18579
-                                                },
-                                                {
-                                                    "name": "서울식품우",
-                                                    "code": "004415",
-                                                    "rank": 18,
-                                                    "price": 1200,
-                                                    "prdyVrss": -35,
-                                                    "prdyCtrt": -2.83,
-                                                    "avrgVol": 18492
-                                                },
-                                                {
-                                                    "name": "한국금융지주우",
-                                                    "code": "071055",
-                                                    "rank": 19,
-                                                    "price": 56000,
-                                                    "prdyVrss": 1100,
-                                                    "prdyCtrt": 2.0,
-                                                    "avrgVol": 16998
-                                                },
-                                                {
-                                                    "name": "한화솔루션우",
-                                                    "code": "009835",
-                                                    "rank": 20,
-                                                    "price": 17420,
-                                                    "prdyVrss": -870,
-                                                    "prdyCtrt": -4.76,
-                                                    "avrgVol": 15958
-                                                },
-                                                {
-                                                    "name": "대덕전자1우",
-                                                    "code": "35320K",
-                                                    "rank": 21,
-                                                    "price": 8280,
-                                                    "prdyVrss": 150,
-                                                    "prdyCtrt": 1.85,
-                                                    "avrgVol": 14840
-                                                },
-                                                {
-                                                    "name": "대한제당우",
-                                                    "code": "001795",
-                                                    "rank": 22,
-                                                    "price": 2275,
-                                                    "prdyVrss": 5,
-                                                    "prdyCtrt": 0.22,
-                                                    "avrgVol": 14184
-                                                },
-                                                {
-                                                    "name": "한화3우B",
-                                                    "code": "00088K",
-                                                    "rank": 23,
-                                                    "price": 15280,
-                                                    "prdyVrss": 0,
-                                                    "prdyCtrt": 0.0,
-                                                    "avrgVol": 12970
-                                                },
-                                                {
-                                                    "name": "덕성우",
-                                                    "code": "004835",
-                                                    "rank": 24,
-                                                    "price": 9900,
-                                                    "prdyVrss": -20,
-                                                    "prdyCtrt": -0.2,
-                                                    "avrgVol": 12053
-                                                },
-                                                {
-                                                    "name": "대상우",
-                                                    "code": "001685",
-                                                    "rank": 25,
-                                                    "price": 15540,
-                                                    "prdyVrss": -90,
-                                                    "prdyCtrt": -0.58,
-                                                    "avrgVol": 11151
-                                                },
-                                                {
-                                                    "name": "유한양행우",
-                                                    "code": "000105",
-                                                    "rank": 26,
-                                                    "price": 118500,
-                                                    "prdyVrss": 500,
-                                                    "prdyCtrt": 0.42,
-                                                    "avrgVol": 10607
-                                                },
-                                                {
-                                                    "name": "태양금속우",
-                                                    "code": "004105",
-                                                    "rank": 27,
-                                                    "price": 4700,
-                                                    "prdyVrss": -30,
-                                                    "prdyCtrt": -0.63,
-                                                    "avrgVol": 9601
-                                                },
-                                                {
-                                                    "name": "NPC우",
-                                                    "code": "004255",
-                                                    "rank": 28,
-                                                    "price": 2505,
-                                                    "prdyVrss": -10,
-                                                    "prdyCtrt": -0.4,
-                                                    "avrgVol": 9579
-                                                },
-                                                {
-                                                    "name": "흥국화재우",
-                                                    "code": "000545",
-                                                    "rank": 29,
-                                                    "price": 5120,
-                                                    "prdyVrss": -20,
-                                                    "prdyCtrt": -0.39,
-                                                    "avrgVol": 9061
-                                                },
-                                                {
-                                                    "name": "대상홀딩스우",
-                                                    "code": "084695",
-                                                    "rank": 30,
-                                                    "price": 19360,
-                                                    "prdyVrss": -630,
-                                                    "prdyCtrt": -3.15,
-                                                    "avrgVol": 7971
-                                                }
+                                                "rank": [
+                                                             {
+                                                                 "name": "데이원컴퍼니",
+                                                                 "code": "373160",
+                                                                 "rank": 1,
+                                                                 "price": 7800,
+                                                                 "prdyVrss": -5200,
+                                                                 "prdyCtrt": -40.0,
+                                                                 "avrgVol": 5373704
+                                                             },
+                                                             {
+                                                                 "name": "와이즈넛",
+                                                                 "code": "096250",
+                                                                 "rank": 2,
+                                                                 "price": 10800,
+                                                                 "prdyVrss": -6200,
+                                                                 "prdyCtrt": -36.47,
+                                                                 "avrgVol": 3254006
+                                                             },
+                                                             {
+                                                                 "name": "스타코링크",
+                                                                 "code": "060240",
+                                                                 "rank": 3,
+                                                                 "price": 376,
+                                                                 "prdyVrss": -125,
+                                                                 "prdyCtrt": -24.95,
+                                                                 "avrgVol": 2410117
+                                                             },
+                                                             {
+                                                                 "name": "대영포장",
+                                                                 "code": "014160",
+                                                                 "rank": 4,
+                                                                 "price": 1740,
+                                                                 "prdyVrss": -505,
+                                                                 "prdyCtrt": -22.49,
+                                                                 "avrgVol": 56059534
+                                                             },
+                                                             {
+                                                                 "name": "세원물산",
+                                                                 "code": "024830",
+                                                                 "rank": 5,
+                                                                 "price": 10380,
+                                                                 "prdyVrss": -2420,
+                                                                 "prdyCtrt": -18.91,
+                                                                 "avrgVol": 452062
+                                                             },
+                                                             {
+                                                                 "name": "미트박스",
+                                                                 "code": "475460",
+                                                                 "rank": 6,
+                                                                 "price": 12290,
+                                                                 "prdyVrss": -1910,
+                                                                 "prdyCtrt": -13.45,
+                                                                 "avrgVol": 2134805
+                                                             },
+                                                             {
+                                                                 "name": "원풍물산",
+                                                                 "code": "008290",
+                                                                 "rank": 7,
+                                                                 "price": 499,
+                                                                 "prdyVrss": -76,
+                                                                 "prdyCtrt": -13.22,
+                                                                 "avrgVol": 6049577
+                                                             },
+                                                             {
+                                                                 "name": "우원개발",
+                                                                 "code": "046940",
+                                                                 "rank": 8,
+                                                                 "price": 3155,
+                                                                 "prdyVrss": -470,
+                                                                 "prdyCtrt": -12.97,
+                                                                 "avrgVol": 1584766
+                                                             },
+                                                             {
+                                                                 "name": "사조오양",
+                                                                 "code": "006090",
+                                                                 "rank": 9,
+                                                                 "price": 8740,
+                                                                 "prdyVrss": -1190,
+                                                                 "prdyCtrt": -11.98,
+                                                                 "avrgVol": 237785
+                                                             },
+                                                             {
+                                                                 "name": "케이씨피드",
+                                                                 "code": "025880",
+                                                                 "rank": 10,
+                                                                 "price": 2970,
+                                                                 "prdyVrss": -395,
+                                                                 "prdyCtrt": -11.74,
+                                                                 "avrgVol": 1103958
+                                                             },
+                                                             {
+                                                                 "name": "체리부로",
+                                                                 "code": "066360",
+                                                                 "rank": 11,
+                                                                 "price": 923,
+                                                                 "prdyVrss": -118,
+                                                                 "prdyCtrt": -11.34,
+                                                                 "avrgVol": 1881878
+                                                             },
+                                                             {
+                                                                 "name": "화신정공",
+                                                                 "code": "126640",
+                                                                 "rank": 12,
+                                                                 "price": 1659,
+                                                                 "prdyVrss": -206,
+                                                                 "prdyCtrt": -11.05,
+                                                                 "avrgVol": 2057336
+                                                             },
+                                                             {
+                                                                 "name": "경동나비엔",
+                                                                 "code": "009450",
+                                                                 "rank": 13,
+                                                                 "price": 90500,
+                                                                 "prdyVrss": -10600,
+                                                                 "prdyCtrt": -10.48,
+                                                                 "avrgVol": 251738
+                                                             },
+                                                             {
+                                                                 "name": "베셀",
+                                                                 "code": "177350",
+                                                                 "rank": 14,
+                                                                 "price": 1126,
+                                                                 "prdyVrss": -122,
+                                                                 "prdyCtrt": -9.78,
+                                                                 "avrgVol": 1363326
+                                                             },
+                                                             {
+                                                                 "name": "평화홀딩스",
+                                                                 "code": "010770",
+                                                                 "rank": 15,
+                                                                 "price": 3590,
+                                                                 "prdyVrss": -375,
+                                                                 "prdyCtrt": -9.46,
+                                                                 "avrgVol": 4780459
+                                                             },
+                                                             {
+                                                                 "name": "진영",
+                                                                 "code": "285800",
+                                                                 "rank": 16,
+                                                                 "price": 2960,
+                                                                 "prdyVrss": -305,
+                                                                 "prdyCtrt": -9.34,
+                                                                 "avrgVol": 690875
+                                                             },
+                                                             {
+                                                                 "name": "SNT모티브",
+                                                                 "code": "064960",
+                                                                 "rank": 17,
+                                                                 "price": 25500,
+                                                                 "prdyVrss": -2600,
+                                                                 "prdyCtrt": -9.25,
+                                                                 "avrgVol": 214020
+                                                             },
+                                                             {
+                                                                 "name": "한솔홈데코",
+                                                                 "code": "025750",
+                                                                 "rank": 18,
+                                                                 "price": 1075,
+                                                                 "prdyVrss": -105,
+                                                                 "prdyCtrt": -8.9,
+                                                                 "avrgVol": 10178917
+                                                             },
+                                                             {
+                                                                 "name": "옵티시스",
+                                                                 "code": "109080",
+                                                                 "rank": 19,
+                                                                 "price": 10300,
+                                                                 "prdyVrss": -990,
+                                                                 "prdyCtrt": -8.77,
+                                                                 "avrgVol": 180310
+                                                             },
+                                                             {
+                                                                 "name": "옵티코어",
+                                                                 "code": "380540",
+                                                                 "rank": 20,
+                                                                 "price": 1205,
+                                                                 "prdyVrss": -106,
+                                                                 "prdyCtrt": -8.09,
+                                                                 "avrgVol": 529840
+                                                             },
+                                                             {
+                                                                 "name": "아시아경제",
+                                                                 "code": "127710",
+                                                                 "rank": 21,
+                                                                 "price": 1506,
+                                                                 "prdyVrss": -131,
+                                                                 "prdyCtrt": -8.0,
+                                                                 "avrgVol": 62189
+                                                             },
+                                                             {
+                                                                 "name": "하이퍼코퍼레이션",
+                                                                 "code": "065650",
+                                                                 "rank": 22,
+                                                                 "price": 1098,
+                                                                 "prdyVrss": -94,
+                                                                 "prdyCtrt": -7.89,
+                                                                 "avrgVol": 1148543
+                                                             },
+                                                             {
+                                                                 "name": "아이윈플러스",
+                                                                 "code": "123010",
+                                                                 "rank": 23,
+                                                                 "price": 1520,
+                                                                 "prdyVrss": -130,
+                                                                 "prdyCtrt": -7.88,
+                                                                 "avrgVol": 4564589
+                                                             },
+                                                             {
+                                                                 "name": "원티드랩",
+                                                                 "code": "376980",
+                                                                 "rank": 24,
+                                                                 "price": 7300,
+                                                                 "prdyVrss": -600,
+                                                                 "prdyCtrt": -7.59,
+                                                                 "avrgVol": 211252
+                                                             },
+                                                             {
+                                                                 "name": "삼성 인버스 2X 항셍테크 ETN(H) B",
+                                                                 "code": "Q530122",
+                                                                 "rank": 25,
+                                                                 "price": 10030,
+                                                                 "prdyVrss": -775,
+                                                                 "prdyCtrt": -7.17,
+                                                                 "avrgVol": 19725
+                                                             },
+                                                             {
+                                                                 "name": "KB 인버스 2X 항셍테크 선물 ETN",
+                                                                 "code": "Q580019",
+                                                                 "rank": 26,
+                                                                 "price": 6350,
+                                                                 "prdyVrss": -475,
+                                                                 "prdyCtrt": -6.96,
+                                                                 "avrgVol": 20098
+                                                             },
+                                                             {
+                                                                 "name": "큐라티스",
+                                                                 "code": "348080",
+                                                                 "rank": 27,
+                                                                 "price": 633,
+                                                                 "prdyVrss": -47,
+                                                                 "prdyCtrt": -6.91,
+                                                                 "avrgVol": 642559
+                                                             },
+                                                             {
+                                                                 "name": "젠큐릭스",
+                                                                 "code": "229000",
+                                                                 "rank": 28,
+                                                                 "price": 1878,
+                                                                 "prdyVrss": -137,
+                                                                 "prdyCtrt": -6.8,
+                                                                 "avrgVol": 312885
+                                                             },
+                                                             {
+                                                                 "name": "오킨스전자",
+                                                                 "code": "080580",
+                                                                 "rank": 29,
+                                                                 "price": 5830,
+                                                                 "prdyVrss": -420,
+                                                                 "prdyCtrt": -6.72,
+                                                                 "avrgVol": 496736
+                                                             },
+                                                             {
+                                                                 "name": "한국첨단소재",
+                                                                 "code": "062970",
+                                                                 "rank": 30,
+                                                                 "price": 6400,
+                                                                 "prdyVrss": -460,
+                                                                 "prdyCtrt": -6.71,
+                                                                 "avrgVol": 6561625
+                                                             }
+                                                         ],
+                                                         "time": "2025-01-27 03:02:21"
                                             ]
                                         }
                                 """)


### PR DESCRIPTION
## 배경
- #64 

## 작업 사항
- 한국투자증권 주식 순위 조회 시간 저장 로직 추가하였습니다.
- `LocalDateTIme`저장 시 직렬화 및 형식 지정을 위한 어노테이션, DTO 클래스 추가

## 테스트결과
```
{
    "code": 200,
    "message": "요청이 성공하였습니다.",
    "data": {
        "rank": [
            {
                "name": "데이원컴퍼니",
                "code": "373160",
                "rank": 1,
                "price": 7800,
                "prdyVrss": -5200,
                "prdyCtrt": -40.0,
                "avrgVol": 5373704
            },
...
            {
                "name": "한국첨단소재",
                "code": "062970",
                "rank": 30,
                "price": 6400,
                "prdyVrss": -460,
                "prdyCtrt": -6.71,
                "avrgVol": 6561625
            }
        ],
        "time": "2025-01-27 03:08:00"
    }
}

```

postman 결과를 캡쳐하기에는 내용이 길어 텍스트로 대체합니다. 
결과는 동일합니다.

## 추가 논의
- 저번에 이야기한 것 처럼 Redis 트랜잭션은 적용하지 않았습니다. 
그러나, #51 에서 적용한 예외 처리에 의해 나머지 주식 순위 조회 및 저장 메서드들이 진행되지 않아 에러 발생 이후 메서드는 실행되지 않는 것 같습니다.