### PR TITLE
Feature: 계좌 거래내역 조회 및 Trade 필드 수정

### DIFF
--- a/src/main/java/muzusi/application/account/dto/AccountInfoDto.java
+++ b/src/main/java/muzusi/application/account/dto/AccountInfoDto.java
@@ -4,9 +4,10 @@ import muzusi.domain.account.entity.Account;
 
 public record AccountInfoDto(
         Long id,
-        Long balance
+        Long balance,
+        Long reservedPrice
 ) {
     public static AccountInfoDto fromEntity(Account account) {
-        return new AccountInfoDto(account.getId(), account.getBalance());
+        return new AccountInfoDto(account.getId(), account.getBalance(), account.getReservedPrice());
     }
 }

--- a/src/main/java/muzusi/application/account/dto/TradeInfoDto.java
+++ b/src/main/java/muzusi/application/account/dto/TradeInfoDto.java
@@ -1,0 +1,24 @@
+package muzusi.application.account.dto;
+
+import muzusi.domain.trade.entity.Trade;
+import muzusi.domain.trade.type.TradeType;
+
+import java.time.LocalDateTime;
+
+public record TradeInfoDto(
+        Long id,
+        Long stockPrice,
+        Integer stockCount,
+        String stockName,
+        String stockCode,
+        TradeType tradeType,
+        LocalDateTime tradeAt
+) {
+    public static TradeInfoDto fromEntity(Trade trade) {
+        return new TradeInfoDto(
+                trade.getId(), trade.getStockPrice(),
+                trade.getStockCount(), trade.getStockName(),
+                trade.getStockCode(), trade.getTradeType(), trade.getTradeAt()
+        );
+    }
+}

--- a/src/main/java/muzusi/application/account/service/TradeHistoryService.java
+++ b/src/main/java/muzusi/application/account/service/TradeHistoryService.java
@@ -1,0 +1,33 @@
+package muzusi.application.account.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.account.dto.TradeInfoDto;
+import muzusi.domain.account.entity.Account;
+import muzusi.domain.account.exception.AccountErrorType;
+import muzusi.domain.account.service.AccountService;
+import muzusi.domain.trade.service.TradeService;
+import muzusi.global.exception.CustomException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TradeHistoryService {
+    private final AccountService accountService;
+    private final TradeService tradeService;
+
+    @Transactional(readOnly = true)
+    public List<TradeInfoDto> getTradesByAccountId(Long userId, Long accountId) {
+        Account account = accountService.readById(accountId)
+                .orElseThrow(() -> new CustomException(AccountErrorType.NOT_FOUND));
+
+        if (!account.getUser().getId().equals(userId))
+            throw new CustomException(AccountErrorType.UNAUTHORIZED_ACCESS);
+
+        return tradeService.readByAccountId(accountId)
+                .stream().map(TradeInfoDto::fromEntity)
+                .toList();
+    }
+}

--- a/src/main/java/muzusi/application/trade/dto/TradeReqDto.java
+++ b/src/main/java/muzusi/application/trade/dto/TradeReqDto.java
@@ -21,7 +21,11 @@ public record TradeReqDto(
         @Min(value = 1, message = "주식 개수는 1개 이상이어야 합니다.")
         Integer stockCount,
 
-        @Schema(description = "주식 코드", example = "000610")
+        @Schema(description = "주식 이름", example = "삼성전자")
+        @NotBlank(message = "주식 이름은 필수 정보입니다.")
+        String stockName,
+
+        @Schema(description = "주식 코드", example = "005390")
         @NotBlank(message = "주식 코드는 필수 정보입니다.")
         String stockCode,
 

--- a/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
+++ b/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
@@ -1,7 +1,6 @@
 package muzusi.application.trade.service;
 
 import lombok.RequiredArgsConstructor;
-import muzusi.domain.stock.service.StockService;
 import muzusi.application.trade.dto.TradeReqDto;
 import muzusi.domain.account.entity.Account;
 import muzusi.domain.account.exception.AccountErrorType;
@@ -9,8 +8,6 @@ import muzusi.domain.account.service.AccountService;
 import muzusi.domain.holding.entity.Holding;
 import muzusi.domain.holding.exception.HoldingErrorType;
 import muzusi.domain.holding.service.HoldingService;
-import muzusi.domain.stock.entity.Stock;
-import muzusi.domain.stock.exception.StockErrorType;
 import muzusi.domain.trade.entity.Trade;
 import muzusi.domain.trade.service.TradeService;
 import muzusi.domain.trade.type.TradeType;
@@ -24,7 +21,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class StockTradeExecutor {
     private final TradeService tradeService;
-    private final StockService stockService;
     private final AccountService accountService;
     private final HoldingService holdingService;
     private final UserService userService;
@@ -45,15 +41,13 @@ public class StockTradeExecutor {
         if (tradeReqDto.tradeType() == TradeType.SELL)
             handleStockSale(tradeReqDto, account, userId);
 
-        Stock stock = stockService.readByStockCode(tradeReqDto.stockCode())
-                .orElseThrow(() -> new CustomException(StockErrorType.NOT_FOUND));
-
         tradeService.save(
                 Trade.builder()
                         .stockPrice(tradeReqDto.stockPrice())
                         .stockCount(tradeReqDto.stockCount())
+                        .stockName(tradeReqDto.stockName())
+                        .stockCode(tradeReqDto.stockCode())
                         .tradeType(tradeReqDto.tradeType())
-                        .stock(stock)
                         .account(account)
                         .build()
         );

--- a/src/main/java/muzusi/application/trade/service/TradeReservationHandler.java
+++ b/src/main/java/muzusi/application/trade/service/TradeReservationHandler.java
@@ -38,6 +38,7 @@ public class TradeReservationHandler {
                 .userId(userId)
                 .inputPrice(tradeReqDto.inputPrice())
                 .stockCount(tradeReqDto.stockCount())
+                .stockName(tradeReqDto.stockName())
                 .stockCode(tradeReqDto.stockCode())
                 .tradeType(tradeReqDto.tradeType())
                 .build();

--- a/src/main/java/muzusi/domain/account/exception/AccountErrorType.java
+++ b/src/main/java/muzusi/domain/account/exception/AccountErrorType.java
@@ -11,7 +11,8 @@ import org.springframework.http.HttpStatus;
 public enum AccountErrorType implements BaseErrorType {
     NOT_FOUND(HttpStatus.NOT_FOUND, "4001", "계좌가 존재하지 않습니다."),
     INSUFFICIENT_BALANCE(HttpStatus.BAD_REQUEST, "4002", "계좌 잔액이 부족합니다."),
-    ACCOUNT_CREATION_LIMIT(HttpStatus.BAD_REQUEST, "4003", "오늘은 이미 계좌를 생성했습니다.")
+    ACCOUNT_CREATION_LIMIT(HttpStatus.BAD_REQUEST, "4003", "오늘은 이미 계좌를 생성했습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "4004", "해당 계좌에 접근 권한이 없습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/muzusi/domain/account/service/AccountService.java
+++ b/src/main/java/muzusi/domain/account/service/AccountService.java
@@ -18,6 +18,10 @@ public class AccountService {
         accountRepository.save(account);
     }
 
+    public Optional<Account> readById(Long id) {
+        return accountRepository.findById(id);
+    }
+
     public List<Account> readAllByUserId(Long userId) {
         return accountRepository.findByUser_Id(userId);
     }

--- a/src/main/java/muzusi/domain/trade/entity/Trade.java
+++ b/src/main/java/muzusi/domain/trade/entity/Trade.java
@@ -16,7 +16,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import muzusi.domain.account.entity.Account;
-import muzusi.domain.stock.entity.Stock;
 import muzusi.domain.trade.type.TradeType;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -38,6 +37,12 @@ public class Trade {
     @Column(name = "stock_count")
     private Integer stockCount;
 
+    @Column(name = "stock_name")
+    private String stockName;
+
+    @Column(name = "stock_code")
+    private String stockCode;
+
     @Column(name = "trade_at")
     @CreatedDate
     private LocalDateTime tradeAt;
@@ -46,19 +51,16 @@ public class Trade {
     private TradeType tradeType;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "stock_id")
-    private Stock stock;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "account_id")
     private Account account;
 
     @Builder
-    public Trade(Long stockPrice, Integer stockCount, TradeType tradeType, Stock stock, Account account) {
+    public Trade(Long stockPrice, Integer stockCount, String stockName, String stockCode, TradeType tradeType, Account account) {
         this.stockPrice = stockPrice;
         this.stockCount = stockCount;
+        this.stockName = stockName;
+        this.stockCode = stockCode;
         this.tradeType = tradeType;
-        this.stock = stock;
         this.account = account;
     }
 }

--- a/src/main/java/muzusi/domain/trade/entity/TradeReservation.java
+++ b/src/main/java/muzusi/domain/trade/entity/TradeReservation.java
@@ -24,6 +24,8 @@ public class TradeReservation {
 
     private Integer stockCount;
 
+    private String stockName;
+
     private String stockCode;
 
     private TradeType tradeType;
@@ -32,10 +34,11 @@ public class TradeReservation {
     private LocalDateTime createdAt;
 
     @Builder
-    public TradeReservation(Long userId, Long inputPrice, Integer stockCount, String stockCode, TradeType tradeType) {
+    public TradeReservation(Long userId, Long inputPrice, Integer stockCount, String stockName, String stockCode, TradeType tradeType) {
         this.userId = userId;
         this.inputPrice = inputPrice;
         this.stockCount = stockCount;
+        this.stockName = stockName;
         this.stockCode = stockCode;
         this.tradeType = tradeType;
     }

--- a/src/main/java/muzusi/domain/trade/repository/TradeRepository.java
+++ b/src/main/java/muzusi/domain/trade/repository/TradeRepository.java
@@ -3,5 +3,8 @@ package muzusi.domain.trade.repository;
 import muzusi.domain.trade.entity.Trade;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TradeRepository extends JpaRepository<Trade, Long> {
+    List<Trade> findByAccount_Id(Long accountId);
 }

--- a/src/main/java/muzusi/domain/trade/service/TradeService.java
+++ b/src/main/java/muzusi/domain/trade/service/TradeService.java
@@ -5,6 +5,8 @@ import muzusi.domain.trade.entity.Trade;
 import muzusi.domain.trade.repository.TradeRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class TradeService {
@@ -12,5 +14,9 @@ public class TradeService {
 
     public void save(Trade trade) {
         tradeRepository.save(trade);
+    }
+
+    public List<Trade> readByAccountId(Long accountId) {
+        return tradeRepository.findByAccount_Id(accountId);
     }
 }

--- a/src/main/java/muzusi/presentation/account/api/AccountApi.java
+++ b/src/main/java/muzusi/presentation/account/api/AccountApi.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import muzusi.global.security.auth.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @ApiGroup(value = "[계좌 API]")
 @Tag(name = "[계좌 API]", description = "계좌 관련 API")
@@ -94,4 +95,58 @@ public interface AccountApi {
                     }))
     })
     ResponseEntity<?> getAccount(@AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @TrackApi(description = "계좌 거래 내역 불러오기")
+    @Operation(summary = "계좌 거래 내역 불러오기", description = "계좌 거래내역을 불러오는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "거래내역 호출 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": [
+                                                {
+                                                    "id": 1,
+                                                    "stockPrice": 60000,
+                                                    "stockCount": 10,
+                                                    "stockName": "삼성전자",
+                                                    "stockCode": "005930",
+                                                    "tradeType": "BUY",
+                                                    "tradeAt": "2025-01-28T21:15:22.81816"
+                                                },
+                                                {
+                                                    "id": 2,
+                                                    "stockPrice": 65000,
+                                                    "stockCount": 10,
+                                                    "stockName": "삼성전자",
+                                                    "stockCode": "005930",
+                                                    "tradeType": "SELL",
+                                                    "tradeAt": "2025-01-28T21:15:37.963513"
+                                                }
+                                            ]
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "계좌 존재하지 않음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": "4001",
+                                            "message": "계좌가 존재하지 않습니다."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": "4004",
+                                            "message": "해당 계좌에 접근 권한이 없습니다."
+                                        }
+                                    """)
+                    })),
+    })
+    ResponseEntity<?> getTradesByAccountId(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                           @PathVariable Long accountId);
 }

--- a/src/main/java/muzusi/presentation/account/api/AccountApi.java
+++ b/src/main/java/muzusi/presentation/account/api/AccountApi.java
@@ -53,13 +53,13 @@ public interface AccountApi {
                                                 "content": [
                                                     {
                                                         "id": 1,
-                                                        "balance": 10000000,
-                                                        "rateOfReturn": 0.0
+                                                        "totalBalance": 10000000,
+                                                        "reservedPrice": 300000
                                                     },
                                                     {
                                                         "id": 2,
-                                                        "balance": 20000000,
-                                                        "rateOfReturn": 100.0
+                                                        "totalBalance": 20000000,
+                                                        "reservedPrice": 300000
                                                     }
                                                 ],
                                                 "page": {
@@ -86,8 +86,8 @@ public interface AccountApi {
                                             "message": "요청이 성공하였습니다.",
                                             "data": {
                                                 "id": 2,
-                                                "balance": 20000000,
-                                                "rateOfReturn": 100.0
+                                                "totalBalance": 20000000,
+                                                "reservedPrice": 300000
                                             }
                                         }
                                     """)

--- a/src/main/java/muzusi/presentation/account/controller/AccountController.java
+++ b/src/main/java/muzusi/presentation/account/controller/AccountController.java
@@ -1,6 +1,7 @@
 package muzusi.presentation.account.controller;
 
 import lombok.RequiredArgsConstructor;
+import muzusi.application.account.service.TradeHistoryService;
 import muzusi.application.account.service.UserAccountService;
 import muzusi.global.response.success.SuccessResponse;
 import muzusi.global.security.auth.CustomUserDetails;
@@ -8,6 +9,7 @@ import muzusi.presentation.account.api.AccountApi;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AccountController implements AccountApi {
     private final UserAccountService userAccountService;
+    private final TradeHistoryService tradeHistoryService;
 
     @Override
     @PostMapping
@@ -39,6 +42,15 @@ public class AccountController implements AccountApi {
     public ResponseEntity<?> getAccount(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok(
                 SuccessResponse.from(userAccountService.getAccount(userDetails.getUserId()))
+        );
+    }
+
+    @Override
+    @GetMapping("/{accountId}")
+    public ResponseEntity<?> getTradesByAccountId(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                  @PathVariable Long accountId) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(tradeHistoryService.getTradesByAccountId(userDetails.getUserId(), accountId))
         );
     }
 }

--- a/src/test/java/muzusi/application/trade/service/StockTradeExecutorTest.java
+++ b/src/test/java/muzusi/application/trade/service/StockTradeExecutorTest.java
@@ -1,6 +1,5 @@
 package muzusi.application.trade.service;
 
-import muzusi.domain.stock.service.StockService;
 import muzusi.application.trade.dto.TradeReqDto;
 import muzusi.domain.account.entity.Account;
 import muzusi.domain.account.exception.AccountErrorType;
@@ -42,8 +41,6 @@ class StockTradeExecutorTest {
     @Mock
     private TradeService tradeService;
     @Mock
-    private StockService stockService;
-    @Mock
     private AccountService accountService;
     @Mock
     private HoldingService holdingService;
@@ -59,8 +56,8 @@ class StockTradeExecutorTest {
 
     @BeforeEach
     void setUp() {
-        buyTradeDto = new TradeReqDto(3000L, 3000L, 5, "000610", TradeType.BUY);
-        sellTradeDto = new TradeReqDto(3000L, 3000L, 3, "000610", TradeType.SELL);
+        buyTradeDto = new TradeReqDto(3000L, 3000L, 5, "삼성전자", "005390", TradeType.BUY);
+        sellTradeDto = new TradeReqDto(3000L, 3000L, 3, "삼성전자", "005390", TradeType.SELL);
 
         account = Account.builder()
                 .balance(Account.INITIAL_BALANCE)
@@ -89,7 +86,6 @@ class StockTradeExecutorTest {
     void executeTradeBuyNewHolding() {
         // given
         given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
-        given(stockService.readByStockCode(buyTradeDto.stockCode())).willReturn(Optional.of(stock));
         given(userService.readById(1L)).willReturn(Optional.of(user));
         given(holdingService.existsByUserIdAndStockCode(1L, buyTradeDto.stockCode())).willReturn(false);
 
@@ -107,7 +103,6 @@ class StockTradeExecutorTest {
     void executeTradeBuyExistingHolding() {
         // given
         given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
-        given(stockService.readByStockCode(buyTradeDto.stockCode())).willReturn(Optional.of(stock));
         given(holdingService.existsByUserIdAndStockCode(1L, buyTradeDto.stockCode())).willReturn(true);
         given(holdingService.readByUserIdAndStockCode(1L, buyTradeDto.stockCode())).willReturn(Optional.of(holding));
 
@@ -135,7 +130,6 @@ class StockTradeExecutorTest {
     void executeTradeSellSuccess() {
         // given
         given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
-        given(stockService.readByStockCode(sellTradeDto.stockCode())).willReturn(Optional.of(stock));
         given(holdingService.readByUserIdAndStockCode(1L, sellTradeDto.stockCode())).willReturn(Optional.of(holding));
 
         // when
@@ -168,10 +162,9 @@ class StockTradeExecutorTest {
     @DisplayName("매도 실행 테스트 - 보유 주식이 0이 되면 삭제")
     void executeTradeSellDeleteHoldingWhenZero() {
         // given
-        TradeReqDto fullSellTradeDto = new TradeReqDto(3000L, 3000L, holding.getStockCount(), "000610", TradeType.SELL);
+        TradeReqDto fullSellTradeDto = new TradeReqDto(3000L, 3000L, holding.getStockCount(), "삼성전자", "005390", TradeType.SELL);
 
         given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
-        given(stockService.readByStockCode(fullSellTradeDto.stockCode())).willReturn(Optional.of(stock));
         given(holdingService.readByUserIdAndStockCode(1L, fullSellTradeDto.stockCode())).willReturn(Optional.of(holding));
 
         // when
@@ -210,7 +203,7 @@ class StockTradeExecutorTest {
         // given
         given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
         given(holdingService.readByUserIdAndStockCode(1L, sellTradeDto.stockCode())).willReturn(Optional.of(holding));
-        TradeReqDto invalidSellTradeDto = new TradeReqDto(3000L, 3000L, 100, "000610", TradeType.SELL);
+        TradeReqDto invalidSellTradeDto = new TradeReqDto(3000L, 3000L, 100, "삼성전자", "005390", TradeType.SELL);
 
         // when
         CustomException exception = assertThrows(CustomException.class, () ->

--- a/src/test/java/muzusi/application/trade/service/StockTradeServiceTest.java
+++ b/src/test/java/muzusi/application/trade/service/StockTradeServiceTest.java
@@ -32,8 +32,8 @@ class StockTradeServiceTest {
 
     @BeforeEach
     void setUp() {
-        buyTradeDto = new TradeReqDto(3000L, 3100L, 5, "000610", TradeType.BUY);
-        sellTradeDto = new TradeReqDto(3000L, 2900L, 3, "000610", TradeType.SELL);
+        buyTradeDto = new TradeReqDto(3000L, 3100L, 5, "삼성전자", "005390", TradeType.BUY);
+        sellTradeDto = new TradeReqDto(3000L, 2900L, 3, "삼성전자", "005390", TradeType.SELL);
     }
 
     @Test
@@ -53,7 +53,7 @@ class StockTradeServiceTest {
     @DisplayName("매수 예약 테스트")
     void tradeStockBuyReservation() {
         // given
-        TradeReqDto buyReservationDto = new TradeReqDto(3000L, 2900L, 5, "000610", TradeType.BUY);
+        TradeReqDto buyReservationDto = new TradeReqDto(3000L, 2900L, 5, "삼성전자", "005390", TradeType.BUY);
 
         // when
         stockTradeService.tradeStock(1L, buyReservationDto);
@@ -80,7 +80,7 @@ class StockTradeServiceTest {
     @DisplayName("매도 예약 테스트")
     void tradeStockSellReservation() {
         // given
-        TradeReqDto sellReservationDto = new TradeReqDto(3000L, 3100L, 3, "000610", TradeType.SELL);
+        TradeReqDto sellReservationDto = new TradeReqDto(3000L, 3100L, 3, "삼성전자", "005390", TradeType.SELL);
 
         // when
         stockTradeService.tradeStock(1L, sellReservationDto);

--- a/src/test/java/muzusi/application/trade/service/TradeReservationHandlerTest.java
+++ b/src/test/java/muzusi/application/trade/service/TradeReservationHandlerTest.java
@@ -51,8 +51,8 @@ class TradeReservationHandlerTest {
 
     @BeforeEach
     void setUp() {
-        buyTradeDto = new TradeReqDto(3500L, 3000L, 5, "000610", TradeType.BUY);
-        sellTradeDto = new TradeReqDto(2500L, 3000L, 3, "000610", TradeType.SELL);
+        buyTradeDto = new TradeReqDto(3500L, 3000L, 5, "삼성전자", "005390", TradeType.BUY);
+        sellTradeDto = new TradeReqDto(2500L, 3000L, 3, "삼성전자", "005390", TradeType.SELL);
 
         account = Account.builder()
                 .balance(Account.INITIAL_BALANCE)
@@ -137,7 +137,7 @@ class TradeReservationHandlerTest {
     @DisplayName("매도 예약 실패 테스트 - 수량 부족")
     void handleReservationSaleFalseTest() {
         // given
-        TradeReqDto overCountDto = new TradeReqDto(2500L, 3000L, 15, "000610", TradeType.SELL);
+        TradeReqDto overCountDto = new TradeReqDto(2500L, 3000L, 15, "삼성전자", "005390", TradeType.SELL);
         given(holdingService.readByUserIdAndStockCode(1L, buyTradeDto.stockCode())).willReturn(Optional.of(holding));
 
         // when


### PR DESCRIPTION
## 배경
1. 계좌의 거래내역을 알 필요가 있음.
2. Trade에 StockName을 넣어 주식 종목에 대해 반환해주어야 함. 그래서 말했던 것처럼, 매핑보다는 필드명 자체를 넣는게 좋다고 판단

## 작업 사항
- 계좌 내역 정보 반환 시, 예약 거래에 대한 금액도 같이 반환 `reversedPrice`
- 계좌 거래내역 반환 추가
- Trade 필드 변경

## 추가 논의
x