### PR TITLE
Feature: 주식 검색어 자동완성 구현

### DIFF
--- a/src/main/java/muzusi/application/stock/service/StockHistoryService.java
+++ b/src/main/java/muzusi/application/stock/service/StockHistoryService.java
@@ -19,6 +19,18 @@ public class StockHistoryService {
     private final StockMonthlyService stockMonthlyService;
     private final StockYearlyService stockYearlyService;
 
+    /**
+     * 과거 주식 차트 불러오는 메서드
+     * StockPeriodType
+     * - DAILY: 일 단위 주식 차트 데이터를 조회
+     * - WEEKLY: 주 단위 주식 차트 데이터를 조회
+     * - MONTHLY: 월 단위 주식 차트 데이터를 조회
+     * - YEARLY: 연 단위 주식 차트 데이터를 조회
+     *
+     * @param stockCode : 주식 코드
+     * @param stockPeriodType : 주식 차트 기간 유형 (DAILY, WEEKLY, MONTHLY, YEARLY)
+     * @return 과거 주식 차트
+     */
     public List<StockChartInfoDto> getStockHistoryByType(String stockCode, StockPeriodType stockPeriodType) {
         return switch (stockPeriodType) {
             case DAILY -> stockDailyService.readByStockCode(stockCode)

--- a/src/main/java/muzusi/application/stock/service/StockSearchService.java
+++ b/src/main/java/muzusi/application/stock/service/StockSearchService.java
@@ -1,0 +1,37 @@
+package muzusi.application.stock.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.stock.entity.StockItem;
+import muzusi.infrastructure.repository.StockInMemoryRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StockSearchService {
+    private final StockInMemoryRepository stockInMemoryRepository;
+
+    /**
+     * 검색어 자동완성을 위한 주식 검색 메서드
+     * 정렬 기준:
+     * 1. 해당 종목이 검색된 횟수가 많은 순 (내림차순)
+     * 2. 검색 횟수가 동일한 경우, 종목명을 기준으로 오름차순 정렬
+     *
+     * @param keyword : 사용자 입력한 값
+     * @return : 자동완성 리스트
+     */
+    public List<StockItem> searchStocks(String keyword) {
+        List<StockItem> stockItems = stockInMemoryRepository.findByKeyword(keyword);
+
+        stockItems.sort((s1, s2) -> {
+            int count1 = stockInMemoryRepository.findSearchCountByStockName(s1.getStockName());
+            int count2 = stockInMemoryRepository.findSearchCountByStockName(s2.getStockName());
+            if (count1 == count2)
+                return s1.getStockName().compareTo(s2.getStockName());
+            return count2 - count1;
+        });
+
+        return stockItems;
+    }
+}

--- a/src/main/java/muzusi/domain/stock/entity/StockItem.java
+++ b/src/main/java/muzusi/domain/stock/entity/StockItem.java
@@ -1,0 +1,11 @@
+package muzusi.domain.stock.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StockItem {
+    private String stockName;
+    private String stockCode;
+}

--- a/src/main/java/muzusi/infrastructure/repository/StockInMemoryRepository.java
+++ b/src/main/java/muzusi/infrastructure/repository/StockInMemoryRepository.java
@@ -1,0 +1,65 @@
+package muzusi.infrastructure.repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.stock.entity.StockItem;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class StockInMemoryRepository {
+    private static final String STOCK_ZSET_KEY = "stock:zset";
+    private static final String STOCK_DATA_KEY = "stock:data";
+    private static final String STOCK_SEARCH_COUNT_KEY = "stock:search:count";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void saveAll(List<StockItem> stocks) {
+        for (StockItem stock : stocks) {
+            try {
+                String stockJson = objectMapper.writeValueAsString(stock);
+                redisTemplate.opsForZSet().add(STOCK_ZSET_KEY, stock.getStockName(), 0);
+                redisTemplate.opsForHash().put(STOCK_DATA_KEY, stock.getStockName(), stockJson);
+            } catch (JsonProcessingException ignored) { }
+        }
+    }
+
+    public List<StockItem> findByKeyword(String keyword) {
+        Cursor<ZSetOperations.TypedTuple<String>> stockCursor =
+                redisTemplate.opsForZSet().scan(STOCK_ZSET_KEY, ScanOptions.scanOptions().match("*" + keyword + "*").build());
+
+        List<StockItem> matchingStocks = new ArrayList<>();
+        int count = 0;
+
+        while (stockCursor.hasNext() && count < 20) {
+            String stockName = stockCursor.next().getValue();
+            String stockJson = (String) redisTemplate.opsForHash().get(STOCK_DATA_KEY, stockName);
+            try {
+                matchingStocks.add(objectMapper.readValue(stockJson, StockItem.class));
+                count++;
+            } catch (JsonProcessingException ignored) { }
+        }
+
+        return matchingStocks;
+    }
+
+    public int findSearchCountByStockName(String stockName) {
+        return Optional.ofNullable((String) redisTemplate.opsForHash().get(STOCK_SEARCH_COUNT_KEY, stockName))
+                .map(Integer::parseInt)
+                .orElse(0);
+    }
+
+    public void incrementSearchCount(String stockName) {
+        redisTemplate.opsForHash().increment(STOCK_SEARCH_COUNT_KEY, stockName, 1);
+    }
+}

--- a/src/main/java/muzusi/presentation/stock/api/StockApi.java
+++ b/src/main/java/muzusi/presentation/stock/api/StockApi.java
@@ -1,0 +1,42 @@
+package muzusi.presentation.stock.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@ApiGroup(value = "[주식 API]")
+@Tag(name = "[주식 API]", description = "주식 관련 API")
+public interface StockApi {
+
+    @TrackApi(description = "주식 검색어 자동완성")
+    @Operation(summary = "주식 검색어 자동완성", description = "주식 검색어 자동완성하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주식 검색어 자동완성",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": [
+                                                {
+                                                     "stockCode": "005930",
+                                                     "stockName": "삼성전자"
+                                                },
+                                                {
+                                                     "stockCode": "035420",
+                                                     "stockName": "네이버"
+                                                }
+                                            ]
+                                        }
+                                """)
+                    }))
+    })
+    ResponseEntity<?> searchStock(@RequestParam String keyword);
+}

--- a/src/main/java/muzusi/presentation/stock/controller/StockController.java
+++ b/src/main/java/muzusi/presentation/stock/controller/StockController.java
@@ -3,6 +3,7 @@ package muzusi.presentation.stock.controller;
 import lombok.RequiredArgsConstructor;
 import muzusi.application.stock.service.StockSearchService;
 import muzusi.global.response.success.SuccessResponse;
+import muzusi.presentation.stock.api.StockApi;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,9 +13,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/stocks")
 @RequiredArgsConstructor
-public class StockController {
+public class StockController implements StockApi {
     private final StockSearchService stockSearchService;
 
+    @Override
     @GetMapping
     public ResponseEntity<?> searchStock(@RequestParam String keyword) {
         return ResponseEntity.ok(

--- a/src/main/java/muzusi/presentation/stock/controller/StockController.java
+++ b/src/main/java/muzusi/presentation/stock/controller/StockController.java
@@ -1,0 +1,24 @@
+package muzusi.presentation.stock.controller;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.stock.service.StockSearchService;
+import muzusi.global.response.success.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/stocks")
+@RequiredArgsConstructor
+public class StockController {
+    private final StockSearchService stockSearchService;
+
+    @GetMapping
+    public ResponseEntity<?> searchStock(@RequestParam String keyword) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(stockSearchService.searchStocks(keyword))
+        );
+    }
+}


### PR DESCRIPTION
## 배경
- 검색창에서 주식에 대한 자동 완성과 종목코드를 매핑해서 보내줘야 함.

## 작업 사항
- 검색어를 통한 주식 검색 및 코드 매핑
- 주식 조회수를 기준으로 정렬 구현

## 추가 논의
- 레디스를 사용해야할까? 라는 생각에 그냥 서버 자체에 저장하고자 하였습니다. 하지만, 조회수 값 또한 사라져 검색에 대한 우선순위를 줄 수 없었습니다. 그래서 redis를 사용하였습니다.
- ec2 프리티어 서버인점을 고려하면 100ms 속도가 걸리는데, 이보다 더 빠른 방법이 떠오른다면 의견제시해주세요! 더 좋은 방법 있으면 적용하겠습니다.
- 프론트에서는 검색마다 호출하는 것이 아닌 디바운싱을 사용하여 호출하면 부하가 적을 것 같습니다!

## 테스트
로컬 환경에서 실행한거여서 속도가 ec2보다 빠르게 나왔습니다.
1. 조회수 모두 동일 (이름순 정렬)
![image](https://github.com/user-attachments/assets/d1b2083f-afa7-456c-8000-8cf6fbdbb2b5)
2. 조회수 우선 정렬
![image](https://github.com/user-attachments/assets/7179e1f8-e9d0-41fb-8def-330d6bab1d43)
