### PR TITLE
Feature: 주식 검색어 자동완성 구현

### DIFF
--- a/src/main/java/muzusi/application/stock/dto/StockItemDto.java
+++ b/src/main/java/muzusi/application/stock/dto/StockItemDto.java
@@ -1,0 +1,12 @@
+package muzusi.application.stock.dto;
+
+import muzusi.domain.stock.entity.StockItem;
+
+public record StockItemDto(
+        String stockName,
+        String stockCode
+) {
+    public static StockItemDto fromEntity(StockItem stockItem) {
+        return new StockItemDto(stockItem.getStockName(), stockItem.getStockCode());
+    }
+}

--- a/src/main/java/muzusi/application/stock/service/StockHistoryService.java
+++ b/src/main/java/muzusi/application/stock/service/StockHistoryService.java
@@ -19,6 +19,18 @@ public class StockHistoryService {
     private final StockMonthlyService stockMonthlyService;
     private final StockYearlyService stockYearlyService;
 
+    /**
+     * 과거 주식 차트 불러오는 메서드
+     * StockPeriodType
+     * - DAILY: 일 단위 주식 차트 데이터를 조회
+     * - WEEKLY: 주 단위 주식 차트 데이터를 조회
+     * - MONTHLY: 월 단위 주식 차트 데이터를 조회
+     * - YEARLY: 연 단위 주식 차트 데이터를 조회
+     *
+     * @param stockCode : 주식 코드
+     * @param stockPeriodType : 주식 차트 기간 유형 (DAILY, WEEKLY, MONTHLY, YEARLY)
+     * @return 과거 주식 차트
+     */
     public List<StockChartInfoDto> getStockHistoryByType(String stockCode, StockPeriodType stockPeriodType) {
         return switch (stockPeriodType) {
             case DAILY -> stockDailyService.readByStockCode(stockCode)

--- a/src/main/java/muzusi/application/stock/service/StockSearchService.java
+++ b/src/main/java/muzusi/application/stock/service/StockSearchService.java
@@ -1,0 +1,26 @@
+package muzusi.application.stock.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.stock.dto.StockItemDto;
+import muzusi.domain.stock.service.StockItemService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StockSearchService {
+    private final StockItemService stockItemService;
+
+    /**
+     * 검색어 자동완성을 위한 주식 검색 메서드
+     *
+     * @param keyword : 사용자 입력한 값
+     * @return : 자동완성 리스트
+     */
+    public List<StockItemDto> searchStocks(String keyword) {
+        return stockItemService.readByKeyword(keyword)
+                .stream().map(StockItemDto::fromEntity)
+                .toList();
+    }
+}

--- a/src/main/java/muzusi/domain/stock/entity/StockItem.java
+++ b/src/main/java/muzusi/domain/stock/entity/StockItem.java
@@ -1,0 +1,28 @@
+package muzusi.domain.stock.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "stock_item")
+public class StockItem {
+    @Id
+    private String id;
+
+    private String stockName;
+
+    private String stockCode;
+
+    private int searchCount;
+
+    @Builder
+    public StockItem(String stockName, String stockCode) {
+        this.stockName = stockName;
+        this.stockCode = stockCode;
+    }
+}

--- a/src/main/java/muzusi/domain/stock/repository/StockItemCustomRepository.java
+++ b/src/main/java/muzusi/domain/stock/repository/StockItemCustomRepository.java
@@ -1,0 +1,5 @@
+package muzusi.domain.stock.repository;
+
+public interface StockItemCustomRepository {
+    void incrementSearchCount(String stockCode);
+}

--- a/src/main/java/muzusi/domain/stock/repository/StockItemCustomRepositoryImpl.java
+++ b/src/main/java/muzusi/domain/stock/repository/StockItemCustomRepositoryImpl.java
@@ -1,0 +1,20 @@
+package muzusi.domain.stock.repository;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.stock.entity.StockItem;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+@RequiredArgsConstructor
+public class StockItemCustomRepositoryImpl implements StockItemCustomRepository {
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public void incrementSearchCount(String stockCode) {
+        Query query = new Query(Criteria.where("stockCode").is(stockCode));
+        Update update = new Update().inc("searchCount", 1);
+        mongoTemplate.updateFirst(query, update, StockItem.class);
+    }
+}

--- a/src/main/java/muzusi/domain/stock/repository/StockItemRepository.java
+++ b/src/main/java/muzusi/domain/stock/repository/StockItemRepository.java
@@ -1,0 +1,16 @@
+package muzusi.domain.stock.repository;
+
+import muzusi.domain.stock.entity.StockItem;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+
+import java.util.List;
+
+public interface StockItemRepository extends MongoRepository<StockItem, String>, StockItemCustomRepository {
+
+    @Query(value = "{'stockName': {$regex: ?0, $options: 'i'}}", sort = "{'searchCount': -1, 'stockName': 1}")
+    List<StockItem> findByKeyword(String keyword, Pageable pageable);
+
+
+}

--- a/src/main/java/muzusi/domain/stock/repository/StockItemRepository.java
+++ b/src/main/java/muzusi/domain/stock/repository/StockItemRepository.java
@@ -11,6 +11,4 @@ public interface StockItemRepository extends MongoRepository<StockItem, String>,
 
     @Query(value = "{'stockName': {$regex: ?0, $options: 'i'}}", sort = "{'searchCount': -1, 'stockName': 1}")
     List<StockItem> findByKeyword(String keyword, Pageable pageable);
-
-
 }

--- a/src/main/java/muzusi/domain/stock/service/StockItemService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockItemService.java
@@ -1,0 +1,27 @@
+package muzusi.domain.stock.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.stock.entity.StockItem;
+import muzusi.domain.stock.repository.StockItemRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StockItemService {
+    private final StockItemRepository stockItemRepository;
+
+    public void saveAll(List<StockItem> stockItems) {
+        stockItemRepository.saveAll(stockItems);
+    }
+
+    public List<StockItem> readByKeyword(String keyword) {
+        return stockItemRepository.findByKeyword(keyword, PageRequest.of(0, 20));
+    }
+
+    public void updateSearchCount(String stockCode) {
+        stockItemRepository.incrementSearchCount(stockCode);
+    }
+}

--- a/src/main/java/muzusi/presentation/stock/api/StockApi.java
+++ b/src/main/java/muzusi/presentation/stock/api/StockApi.java
@@ -1,0 +1,42 @@
+package muzusi.presentation.stock.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@ApiGroup(value = "[주식 API]")
+@Tag(name = "[주식 API]", description = "주식 관련 API")
+public interface StockApi {
+
+    @TrackApi(description = "주식 검색어 자동완성")
+    @Operation(summary = "주식 검색어 자동완성", description = "주식 검색어 자동완성하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주식 검색어 자동완성",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": [
+                                                {
+                                                     "stockCode": "035420",
+                                                     "stockName": "네이버"
+                                                },
+                                                {
+                                                     "stockCode": "005930",
+                                                     "stockName": "삼성전자"
+                                                }
+                                            ]
+                                        }
+                                """)
+                    }))
+    })
+    ResponseEntity<?> searchStock(@RequestParam String keyword);
+}

--- a/src/main/java/muzusi/presentation/stock/controller/StockController.java
+++ b/src/main/java/muzusi/presentation/stock/controller/StockController.java
@@ -3,6 +3,7 @@ package muzusi.presentation.stock.controller;
 import lombok.RequiredArgsConstructor;
 import muzusi.application.stock.service.StockSearchService;
 import muzusi.global.response.success.SuccessResponse;
+import muzusi.presentation.stock.api.StockApi;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,9 +13,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/stocks")
 @RequiredArgsConstructor
-public class StockController {
+public class StockController implements StockApi {
     private final StockSearchService stockSearchService;
 
+    @Override
     @GetMapping
     public ResponseEntity<?> searchStock(@RequestParam String keyword) {
         return ResponseEntity.ok(

--- a/src/main/java/muzusi/presentation/stock/controller/StockController.java
+++ b/src/main/java/muzusi/presentation/stock/controller/StockController.java
@@ -1,0 +1,24 @@
+package muzusi.presentation.stock.controller;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.stock.service.StockSearchService;
+import muzusi.global.response.success.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/stocks")
+@RequiredArgsConstructor
+public class StockController {
+    private final StockSearchService stockSearchService;
+
+    @GetMapping
+    public ResponseEntity<?> searchStock(@RequestParam String keyword) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(stockSearchService.searchStocks(keyword))
+        );
+    }
+}


### PR DESCRIPTION
## 배경
- 검색창에서 주식에 대한 자동 완성과 종목코드를 매핑해서 보내줘야 함.

## 작업 사항
- 검색어를 통한 주식 검색 및 코드 매핑
- 주식 조회수를 기준으로 정렬 구현 (조회수 기준 내림차순 -> 이름 기준 오름차순)

## 추가 논의
- DB, Redis, 서버 내 메모리 등 다양한 시도를 해봤는데, 영구적인 저장과 속도를 고려했을 때, MongoDB를 이용하는 것이 적절하여 적용했습니다!
다른 의견 있다면 말씀해주세요!
- 프론트에서는 검색마다 호출하는 것이 아닌 디바운싱을 사용하여 호출하면 부하가 적을 것 같습니다!
- 종목에 들어가면 (특정 종목에 들어가 웹소켓 연결하면) stockCode를 통해서 `StockItemService`에 searchCount 업데이트하면 될 것 같습니다! (조회수로 검색어를 정렬하기 위함)

## 테스트
1. 조회수 모두 동일 (이름순 정렬)
![image](https://github.com/user-attachments/assets/e766d7d8-ffc3-434f-a3ac-e16787fdc94d)

2. 조회수 우선 정렬
<img width="753" alt="스크린샷 2025-01-29 오후 3 36 28" src="https://github.com/user-attachments/assets/7cd99dd6-9470-4034-8035-a7852cbf080d" />
