### PR TITLE
Feature: 장 마감 시, 예약 내역 삭제 로직 구현

### DIFF
--- a/src/main/java/muzusi/application/trade/scheduler/TradeScheduler.java
+++ b/src/main/java/muzusi/application/trade/scheduler/TradeScheduler.java
@@ -1,0 +1,17 @@
+package muzusi.application.trade.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.trade.service.TradeReservationCleaner;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TradeScheduler {
+    private final TradeReservationCleaner tradeReservationCleaner;
+
+    @Scheduled(cron = "0 30 15 * * MON-FRI")
+    public void runReservationDeleteJob() {
+        tradeReservationCleaner.clearReservedOrdersAtMarketClose();
+    }
+}

--- a/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
+++ b/src/main/java/muzusi/application/trade/service/StockTradeExecutor.java
@@ -76,6 +76,7 @@ public class StockTradeExecutor {
 
             holdingService.save(
                     Holding.builder()
+                            .stockName(tradeReqDto.stockName())
                             .stockCode(tradeReqDto.stockCode())
                             .stockCount(tradeReqDto.stockCount())
                             .averagePrice(tradeReqDto.stockPrice())

--- a/src/main/java/muzusi/application/trade/service/TradeReservationCleaner.java
+++ b/src/main/java/muzusi/application/trade/service/TradeReservationCleaner.java
@@ -1,0 +1,99 @@
+package muzusi.application.trade.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.account.entity.Account;
+import muzusi.domain.account.exception.AccountErrorType;
+import muzusi.domain.account.service.AccountService;
+import muzusi.domain.holding.entity.Holding;
+import muzusi.domain.holding.exception.HoldingErrorType;
+import muzusi.domain.holding.service.HoldingService;
+import muzusi.domain.trade.service.TradeReservationService;
+import muzusi.domain.trade.type.TradeType;
+import muzusi.global.exception.CustomException;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class TradeReservationCleaner {
+    private final TradeReservationService tradeReservationService;
+    private final AccountService accountService;
+    private final HoldingService holdingService;
+
+    /**
+     * 주식 장 마감 후, 미처리 예약 삭제 메서드
+     * 1. 미처리 예약 매수/매도 별 userId로 구분하여 값 수집
+     * 2. 매수/매도 별 userId를 통해 예약 취소 처리
+     * 3. 예약 내역 삭제
+     */
+    @Transactional
+    public void clearReservedOrdersAtMarketClose() {
+        Pair<Map<Long, Long>, Map<Long, Map<String, Integer>>> totalAmounts = calculateTotalAmounts();
+        Map<Long, Long> totalBuyAmountMap = totalAmounts.getLeft();
+        Map<Long, Map<String, Integer>> totalSellStockMap = totalAmounts.getRight();
+
+        updateReservedBuyAmounts(totalBuyAmountMap);
+        updateReservedSellStocks(totalSellStockMap);
+
+        tradeReservationService.deleteAll();
+    }
+
+    /**
+     * userId 및 매수/매도 별 예약 내역 값 분리
+     *
+     * @return 왼 : 예약 매수 값 분리. 오 : 예약 매도 값 분리.
+     */
+    private Pair<Map<Long, Long>, Map<Long, Map<String, Integer>>> calculateTotalAmounts() {
+        Map<Long, Long> totalBuyAmountMap = new HashMap<>();
+        Map<Long, Map<String, Integer>> totalSellStockMap = new HashMap<>();
+
+        tradeReservationService.readAll().forEach(reservation -> {
+            Long userId = reservation.getUserId();
+            if (reservation.getTradeType() == TradeType.BUY) {
+                totalBuyAmountMap.merge(
+                        userId,
+                        reservation.getInputPrice() * reservation.getStockCount(),
+                        Long::sum
+                );
+            } else if (reservation.getTradeType() == TradeType.SELL) {
+                totalSellStockMap.computeIfAbsent(userId, k -> new HashMap<>())
+                        .merge(reservation.getStockCode(), reservation.getStockCount(), Integer::sum);
+
+            }
+        });
+
+        return Pair.of(totalBuyAmountMap, totalSellStockMap);
+    }
+
+    /**
+     * 예약 매수 내역 취소 처리
+     *
+     * @param totalBuyAmountMap : key - userId, value - 예약 매수 내역
+     */
+    private void updateReservedBuyAmounts(Map<Long, Long> totalBuyAmountMap) {
+        totalBuyAmountMap.forEach((userId, totalBuyAmount) -> {
+            Account account = accountService.readByUserId(userId)
+                    .orElseThrow(() -> new CustomException(AccountErrorType.NOT_FOUND));
+            account.decreaseReservedPrice(totalBuyAmount);
+        });
+    }
+
+    /**
+     * 예약 매도 내역 취소 처리
+     *
+     * @param totalSellStockMap : key - userId, value - 예약 매도 내역
+     */
+    private void updateReservedSellStocks(Map<Long, Map<String, Integer>> totalSellStockMap) {
+        totalSellStockMap.forEach((userId, stockCounts) ->
+                stockCounts.forEach((stockCode, totalStockCount) -> {
+                    Holding holding = holdingService.readByUserIdAndStockCode(userId, stockCode)
+                            .orElseThrow(() -> new CustomException(HoldingErrorType.NOT_FOUND));
+                    holding.decreaseReservedStock(totalStockCount);
+                })
+        );
+    }
+}

--- a/src/main/java/muzusi/application/trade/service/TradeReservationCleaner.java
+++ b/src/main/java/muzusi/application/trade/service/TradeReservationCleaner.java
@@ -36,8 +36,8 @@ public class TradeReservationCleaner {
         Map<Long, Long> totalBuyAmountMap = totalAmounts.getLeft();
         Map<Long, Map<String, Integer>> totalSellStockMap = totalAmounts.getRight();
 
-        updateReservedBuyAmounts(totalBuyAmountMap);
-        updateReservedSellStocks(totalSellStockMap);
+        discardReservedBuyAmounts(totalBuyAmountMap);
+        discardReservedSellStocks(totalSellStockMap);
 
         tradeReservationService.deleteAll();
     }
@@ -74,7 +74,7 @@ public class TradeReservationCleaner {
      *
      * @param totalBuyAmountMap : key - userId, value - 예약 매수 내역
      */
-    private void updateReservedBuyAmounts(Map<Long, Long> totalBuyAmountMap) {
+    private void discardReservedBuyAmounts(Map<Long, Long> totalBuyAmountMap) {
         totalBuyAmountMap.forEach((userId, totalBuyAmount) -> {
             Account account = accountService.readByUserId(userId)
                     .orElseThrow(() -> new CustomException(AccountErrorType.NOT_FOUND));
@@ -87,7 +87,7 @@ public class TradeReservationCleaner {
      *
      * @param totalSellStockMap : key - userId, value - 예약 매도 내역
      */
-    private void updateReservedSellStocks(Map<Long, Map<String, Integer>> totalSellStockMap) {
+    private void discardReservedSellStocks(Map<Long, Map<String, Integer>> totalSellStockMap) {
         totalSellStockMap.forEach((userId, stockCounts) ->
                 stockCounts.forEach((stockCode, totalStockCount) -> {
                     Holding holding = holdingService.readByUserIdAndStockCode(userId, stockCode)

--- a/src/main/java/muzusi/domain/holding/entity/Holding.java
+++ b/src/main/java/muzusi/domain/holding/entity/Holding.java
@@ -2,6 +2,7 @@ package muzusi.domain.holding.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -15,9 +16,14 @@ import lombok.NoArgsConstructor;
 import muzusi.domain.account.entity.Account;
 import muzusi.domain.user.entity.User;
 import org.hibernate.annotations.DynamicUpdate;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 @Entity(name = "holding")
 @DynamicUpdate
 public class Holding {
@@ -36,6 +42,10 @@ public class Holding {
 
     @Column(name = "average_price", nullable = false)
     private Long averagePrice;
+
+    @Column(name = "holding_at")
+    @CreatedDate
+    private LocalDateTime holdingAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/muzusi/domain/holding/entity/Holding.java
+++ b/src/main/java/muzusi/domain/holding/entity/Holding.java
@@ -31,6 +31,9 @@ public class Holding {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "stock_name", nullable = false)
+    private String stockName;
+
     @Column(name = "stock_code", nullable = false)
     private String stockCode;
 
@@ -56,7 +59,8 @@ public class Holding {
     private Account account;
 
     @Builder
-    public Holding(String stockCode, Integer stockCount, Long averagePrice, User user, Account account) {
+    public Holding(String stockName, String stockCode, Integer stockCount, Long averagePrice, User user, Account account) {
+        this.stockName = stockName;
         this.stockCode = stockCode;
         this.stockCount = stockCount;
         this.averagePrice = averagePrice;

--- a/src/main/java/muzusi/domain/trade/service/TradeReservationService.java
+++ b/src/main/java/muzusi/domain/trade/service/TradeReservationService.java
@@ -5,6 +5,7 @@ import muzusi.domain.trade.entity.TradeReservation;
 import muzusi.domain.trade.repository.TradeReservationRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -16,11 +17,19 @@ public class TradeReservationService {
         tradeReservationRepository.save(reservation);
     }
 
+    public List<TradeReservation> readAll() {
+        return tradeReservationRepository.findAll();
+    }
+
     public Optional<TradeReservation> readById(String id) {
         return tradeReservationRepository.findById(id);
     }
 
     public void deleteById(String id) {
         tradeReservationRepository.deleteById(id);
+    }
+
+    public void deleteAll() {
+        tradeReservationRepository.deleteAll();
     }
 }

--- a/src/test/java/muzusi/application/trade/service/TradeReservationCleanerTest.java
+++ b/src/test/java/muzusi/application/trade/service/TradeReservationCleanerTest.java
@@ -1,0 +1,131 @@
+package muzusi.application.trade.service;
+
+import muzusi.domain.account.entity.Account;
+import muzusi.domain.account.service.AccountService;
+import muzusi.domain.holding.entity.Holding;
+import muzusi.domain.holding.service.HoldingService;
+import muzusi.domain.trade.entity.TradeReservation;
+import muzusi.domain.trade.service.TradeReservationService;
+import muzusi.domain.trade.type.TradeType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TradeReservationCleanerTest {
+
+    @InjectMocks
+    private TradeReservationCleaner tradeReservationCleaner;
+
+    @Mock
+    private TradeReservationService tradeReservationService;
+    @Mock
+    private AccountService accountService;
+    @Mock
+    private HoldingService holdingService;
+
+    private TradeReservation buyReservation1;
+    private TradeReservation buyReservation2;
+    private TradeReservation sellReservation1;
+    private TradeReservation sellReservation2;
+    private Account account1;
+    private Account account2;
+    private Holding holding1;
+    private Holding holding2;
+
+    @BeforeEach
+    void setUp() {
+        buyReservation1 = TradeReservation.builder()
+                .userId(1L)
+                .inputPrice(3000L)
+                .stockCount(5)
+                .stockCode("005390")
+                .tradeType(TradeType.BUY)
+                .build();
+
+        buyReservation2 = TradeReservation.builder()
+                .userId(2L)
+                .inputPrice(3000L)
+                .stockCount(5)
+                .stockCode("005390")
+                .tradeType(TradeType.BUY)
+                .build();
+
+        sellReservation1 = TradeReservation.builder()
+                .userId(1L)
+                .inputPrice(2500L)
+                .stockCount(3)
+                .stockCode("005390")
+                .tradeType(TradeType.SELL)
+                .build();
+
+        sellReservation2 = TradeReservation.builder()
+                .userId(2L)
+                .inputPrice(2500L)
+                .stockCount(3)
+                .stockCode("005390")
+                .tradeType(TradeType.SELL)
+                .build();
+
+        account1 = Account.builder()
+                .balance(Account.INITIAL_BALANCE)
+                .build();
+        account1.increaseReservedPrice(3000L * 5);
+
+        holding1 = Holding.builder()
+                .stockCode("005390")
+                .stockCount(10)
+                .account(account1)
+                .build();
+        holding1.increaseReservedStock(3);
+
+        account2 = Account.builder()
+                .balance(Account.INITIAL_BALANCE)
+                .build();
+        account2.increaseReservedPrice(3000L * 5);
+
+        holding2 = Holding.builder()
+                .stockCode("005390")
+                .stockCount(10)
+                .account(account1)
+                .build();
+        holding2.increaseReservedStock(3);
+    }
+
+    @Test
+    @DisplayName("미처리 예약 삭제 및 계좌/보유 주식 업데이트 테스트")
+    void clearReservedOrdersAtMarketCloseTest() {
+        // given
+        given(tradeReservationService.readAll()).willReturn(
+                List.of(buyReservation1, buyReservation2, sellReservation1, sellReservation2)
+        );
+        given(accountService.readByUserId(1L)).willReturn(Optional.of(account1));
+        given(accountService.readByUserId(2L)).willReturn(Optional.of(account2));
+        given(holdingService.readByUserIdAndStockCode(1L, "005390")).willReturn(Optional.of(holding1));
+        given(holdingService.readByUserIdAndStockCode(2L, "005390")).willReturn(Optional.of(holding2));
+
+
+        // when
+        tradeReservationCleaner.clearReservedOrdersAtMarketClose();
+
+        // then
+        assertEquals(0, account1.getReservedPrice());
+        assertEquals(0, account2.getReservedPrice());
+        assertEquals(0, holding1.getReservedStockCount());
+        assertEquals(0, holding2.getReservedStockCount());
+
+        verify(tradeReservationService, times(1)).deleteAll();
+    }
+}


### PR DESCRIPTION
## 배경
- #60 

## 작업 사항
- 예약 매수/매도 내역 삭제 처리
- 장마감 시간 예약 내역 삭제 스케쥴러 적용

## 추가 논의
- 삭제 로직 중, 같은 Account, Holding에 대해서 여러번 쿼리 호출을 막기 위해 userId 및 매수/매도 내역을 분리하여 처리하였습니다