### PR TITLE
Feature: 주식 예약 내역 성공 처리 로직 구현

### DIFF
--- a/src/main/java/muzusi/application/trade/service/TradeReservationTrigger.java
+++ b/src/main/java/muzusi/application/trade/service/TradeReservationTrigger.java
@@ -16,7 +16,6 @@ import muzusi.domain.user.entity.User;
 import muzusi.domain.user.exception.UserErrorType;
 import muzusi.domain.user.service.UserService;
 import muzusi.global.exception.CustomException;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,7 +34,6 @@ public class TradeReservationTrigger {
      * @param stockCode  : 주식 코드
      * @param stockPrice : 현재 주식 가격
      */
-    @Async
     @Transactional
     public void processTradeReservations(String stockCode, Long stockPrice) {
         tradeReservationService.readByStockCode(stockCode).forEach(reservation -> {

--- a/src/main/java/muzusi/application/trade/service/TradeReservationTrigger.java
+++ b/src/main/java/muzusi/application/trade/service/TradeReservationTrigger.java
@@ -1,0 +1,127 @@
+package muzusi.application.trade.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.account.entity.Account;
+import muzusi.domain.account.exception.AccountErrorType;
+import muzusi.domain.account.service.AccountService;
+import muzusi.domain.holding.entity.Holding;
+import muzusi.domain.holding.exception.HoldingErrorType;
+import muzusi.domain.holding.service.HoldingService;
+import muzusi.domain.trade.entity.Trade;
+import muzusi.domain.trade.entity.TradeReservation;
+import muzusi.domain.trade.service.TradeReservationService;
+import muzusi.domain.trade.service.TradeService;
+import muzusi.domain.trade.type.TradeType;
+import muzusi.domain.user.entity.User;
+import muzusi.domain.user.exception.UserErrorType;
+import muzusi.domain.user.service.UserService;
+import muzusi.global.exception.CustomException;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class TradeReservationTrigger {
+    private final TradeReservationService tradeReservationService;
+    private final AccountService accountService;
+    private final HoldingService holdingService;
+    private final UserService userService;
+    private final TradeService tradeService;
+
+    /**
+     * 예약 내역 도달 확인 및 처리 메서드
+     *
+     * @param stockCode  : 주식 코드
+     * @param stockPrice : 현재 주식 가격
+     */
+    @Async
+    @Transactional
+    public void processTradeReservations(String stockCode, Long stockPrice) {
+        tradeReservationService.readByStockCode(stockCode).forEach(reservation -> {
+            if (reservation.getTradeType() == TradeType.BUY && reservation.getInputPrice() >= stockPrice) {
+                processBuyOrder(reservation);
+            } else if (reservation.getTradeType() == TradeType.SELL && reservation.getInputPrice() <= stockPrice) {
+                processSellOrder(reservation);
+            }
+        });
+    }
+
+    /**
+     * 예약 매수 내역 확인 및 처리
+     *
+     * @param reservation : 예약 내역
+     */
+    private void processBuyOrder(TradeReservation reservation) {
+        Account account = accountService.readByUserId(reservation.getUserId())
+                .orElseThrow(() -> new CustomException(AccountErrorType.NOT_FOUND));
+
+        Holding holding = holdingService.readByUserIdAndStockCode(reservation.getUserId(), reservation.getStockCode())
+                .orElseGet(() -> createNewHolding(reservation, account));
+
+        long price = reservation.getInputPrice() * reservation.getStockCount();
+        account.clearReservedPrice(price);
+        holding.addStock(reservation.getStockCount(), reservation.getInputPrice());
+
+        finalizeTrade(reservation, account);
+    }
+
+    /**
+     * 예약 매도 내역 확인 및 처리
+     *
+     * @param reservation : 예약 내역
+     */
+    private void processSellOrder(TradeReservation reservation) {
+        Account account = accountService.readByUserId(reservation.getUserId())
+                .orElseThrow(() -> new CustomException(AccountErrorType.NOT_FOUND));
+
+        Holding holding = holdingService.readByUserIdAndStockCode(reservation.getUserId(), reservation.getStockCode())
+                .orElseThrow(() -> new CustomException(HoldingErrorType.NOT_FOUND));
+
+        holding.clearReservedStock(reservation.getStockCount());
+        long price = reservation.getInputPrice() * reservation.getStockCount();
+        account.updateAccount(reservation.getTradeType(), price);
+
+        if (holding.isEmpty())
+            holdingService.deleteByUserIdAndStockCode(reservation.getUserId(), reservation.getStockCode());
+
+        finalizeTrade(reservation, account);
+    }
+
+    /**
+     * Holding이 존재하지 않을 경우 새로 생성
+     */
+    private Holding createNewHolding(TradeReservation reservation, Account account) {
+        User foundUser = userService.readById(reservation.getUserId())
+                .orElseThrow(() -> new CustomException(UserErrorType.NOT_FOUND));
+
+        return holdingService.save(
+                Holding.builder()
+                        .stockName(reservation.getStockName())
+                        .stockCode(reservation.getStockCode())
+                        .stockCount(0)
+                        .averagePrice(0L)
+                        .user(foundUser)
+                        .account(account)
+                        .build()
+        );
+    }
+
+    /**
+     * 거래 완료 후 처리 (예약 삭제 및 거래 내역 추가)
+     */
+    private void finalizeTrade(TradeReservation reservation, Account account) {
+        tradeReservationService.deleteById(reservation.getId());
+
+        tradeService.save(
+                Trade.builder()
+                        .stockPrice(reservation.getInputPrice())
+                        .stockCount(reservation.getStockCount())
+                        .stockName(reservation.getStockName())
+                        .stockCode(reservation.getStockCode())
+                        .tradeType(reservation.getTradeType())
+                        .account(account)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/muzusi/application/trade/service/TradeReservationTrigger.java
+++ b/src/main/java/muzusi/application/trade/service/TradeReservationTrigger.java
@@ -36,6 +36,8 @@ public class TradeReservationTrigger {
 
     /**
      * 예약 내역 도달 확인 및 처리 메서드
+     * 1. 예약 매수/매도 별 userId로 구분하여 값 수집 (예약 체결 가능한 값)
+     * 2. 예약 체결 분기별 처리
      *
      * @param stockCode  : 주식 코드
      * @param stockPrice : 현재 주식 가격
@@ -51,6 +53,13 @@ public class TradeReservationTrigger {
         processSellOrders(totalSellStockMap);
     }
 
+    /**
+     * 예약 내역 중 체결 가능한 내역 매수/매도 별 userId로 구분하여 값 수집
+     *
+     * @param stockCode : 주식 코드
+     * @param stockPrice : 현재 주식 가격
+     * @return
+     */
     private Pair<Map<Long, List<TradeReservation>>, Map<Long, List<TradeReservation>>>
     calculateTotalAmounts(
             String stockCode,
@@ -74,6 +83,8 @@ public class TradeReservationTrigger {
 
     /**
      * 예약 매수 내역 확인 및 처리
+     * - userId별 계좌 및 보유 주식 조회 한 번으로 내역 업데이트
+     * - 예약 체결 내역 생성 (trade)
      *
      * @param totalBuyAmountMap : 예약 내역
      */
@@ -99,6 +110,8 @@ public class TradeReservationTrigger {
 
     /**
      * 예약 매도 내역 확인 및 처리
+     * - userId별 계좌 및 보유 주식 조회 한 번으로 내역 업데이트
+     * - 예약 체결 내역 생성 (trade)
      *
      * @param totalSellStockMap : 예약 내역
      */

--- a/src/main/java/muzusi/domain/holding/entity/Holding.java
+++ b/src/main/java/muzusi/domain/holding/entity/Holding.java
@@ -72,9 +72,9 @@ public class Holding {
      * 주식을 추가 매수할 때 평균 단가를 재계산하는 메서드
      */
     public void addStock(int count, long price) {
-        long totalCost = (this.stockCount * this.averagePrice) + (count * price);
+        long totalPrice = (this.stockCount * this.averagePrice) + (count * price);
         this.stockCount += count;
-        this.averagePrice = totalCost / this.stockCount;
+        this.averagePrice = totalPrice / this.stockCount;
     }
 
     /**

--- a/src/main/java/muzusi/domain/holding/service/HoldingService.java
+++ b/src/main/java/muzusi/domain/holding/service/HoldingService.java
@@ -12,8 +12,8 @@ import java.util.Optional;
 public class HoldingService {
     private final HoldingRepository holdingRepository;
 
-    public void save(Holding holding) {
-        holdingRepository.save(holding);
+    public Holding save(Holding holding) {
+        return holdingRepository.save(holding);
     }
 
     public Optional<Holding> readByUserIdAndStockCode(Long userId, String stockCode) {

--- a/src/main/java/muzusi/domain/trade/repository/TradeReservationRepository.java
+++ b/src/main/java/muzusi/domain/trade/repository/TradeReservationRepository.java
@@ -3,5 +3,8 @@ package muzusi.domain.trade.repository;
 import muzusi.domain.trade.entity.TradeReservation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.List;
+
 public interface TradeReservationRepository extends MongoRepository<TradeReservation, String> {
+    List<TradeReservation> findByStockCode(String stockCode);
 }

--- a/src/main/java/muzusi/domain/trade/service/TradeReservationService.java
+++ b/src/main/java/muzusi/domain/trade/service/TradeReservationService.java
@@ -25,6 +25,10 @@ public class TradeReservationService {
         return tradeReservationRepository.findById(id);
     }
 
+    public List<TradeReservation> readByStockCode(String stockCode) {
+        return tradeReservationRepository.findByStockCode(stockCode);
+    }
+
     public void deleteById(String id) {
         tradeReservationRepository.deleteById(id);
     }

--- a/src/test/java/muzusi/application/trade/service/TradeReservationTriggerTest.java
+++ b/src/test/java/muzusi/application/trade/service/TradeReservationTriggerTest.java
@@ -1,0 +1,193 @@
+package muzusi.application.trade.service;
+
+import muzusi.domain.account.entity.Account;
+import muzusi.domain.account.service.AccountService;
+import muzusi.domain.holding.entity.Holding;
+import muzusi.domain.holding.service.HoldingService;
+import muzusi.domain.trade.entity.Trade;
+import muzusi.domain.trade.entity.TradeReservation;
+import muzusi.domain.trade.service.TradeReservationService;
+import muzusi.domain.trade.service.TradeService;
+import muzusi.domain.trade.type.TradeType;
+import muzusi.domain.user.entity.User;
+import muzusi.domain.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TradeReservationTriggerTest {
+
+    @InjectMocks
+    private TradeReservationTrigger tradeReservationTrigger;
+
+    @Mock
+    private TradeReservationService tradeReservationService;
+    @Mock
+    private AccountService accountService;
+    @Mock
+    private HoldingService holdingService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private TradeService tradeService;
+
+    private TradeReservation buyReservation;
+    private TradeReservation sellReservation;
+    private Account account;
+    private Holding holding;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        buyReservation = TradeReservation.builder()
+                .tradeType(TradeType.BUY)
+                .inputPrice(3000L)
+                .stockCount(5)
+                .stockName("삼성전자")
+                .stockCode("005390")
+                .userId(1L)
+                .build();
+
+        sellReservation = TradeReservation.builder()
+                .tradeType(TradeType.SELL)
+                .inputPrice(3000L)
+                .stockCount(3)
+                .stockName("삼성전자")
+                .stockCode("005390")
+                .userId(1L)
+                .build();
+
+        account = Account.builder()
+                .balance(Account.INITIAL_BALANCE)
+                .build();
+        account.increaseReservedPrice(3000L * 5);
+
+        holding = Holding.builder()
+                .stockCode("005390")
+                .stockName("삼성전자")
+                .stockCount(10)
+                .averagePrice(2900L)
+                .account(account)
+                .build();
+        holding.increaseReservedStock(3);
+
+        user = User.builder()
+                .username("testUser")
+                .build();
+    }
+
+    @Test
+    @DisplayName("예약된 매수 주문이 처리됨")
+    void processBuyOrderSuccess() {
+        // given
+        given(tradeReservationService.readByStockCode("005390")).willReturn(List.of(buyReservation));
+        given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
+        given(holdingService.readByUserIdAndStockCode(1L, "005390")).willReturn(Optional.of(holding));
+        int expectedCount = holding.getStockCount() + buyReservation.getStockCount();
+        long expectedPrice = ((holding.getAveragePrice() * holding.getStockCount()) +
+                (buyReservation.getInputPrice() * buyReservation.getStockCount())) / expectedCount;
+
+        // when
+        tradeReservationTrigger.processTradeReservations("005390", 2900L);
+
+        // then
+        assertEquals(0, account.getReservedPrice());
+        assertEquals(expectedCount, holding.getStockCount());
+        assertEquals(expectedPrice, holding.getAveragePrice());
+
+        verify(holdingService, never()).save(any(Holding.class));
+        verify(tradeReservationService, times(1)).deleteById(buyReservation.getId());
+        verify(tradeService, times(1)).save(any(Trade.class));
+    }
+
+    @Test
+    @DisplayName("예약된 매도 주문이 처리됨")
+    void processSellOrderSuccess() {
+        // given
+        given(tradeReservationService.readByStockCode("005390")).willReturn(List.of(sellReservation));
+        given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
+        given(holdingService.readByUserIdAndStockCode(1L, "005390")).willReturn(Optional.of(holding));
+        long expectedBalance = account.getBalance() + (sellReservation.getStockCount() * sellReservation.getInputPrice());
+        int expectedCount = holding.getStockCount() - sellReservation.getStockCount();
+
+        // when
+        tradeReservationTrigger.processTradeReservations("005390", 3100L);
+
+        // then
+        assertEquals(expectedBalance, account.getBalance());
+        assertEquals(expectedCount, holding.getStockCount());
+
+        verify(tradeReservationService, times(1)).deleteById(sellReservation.getId());
+        verify(tradeService, times(1)).save(any(Trade.class));
+    }
+
+    @Test
+    @DisplayName("보유 주식이 없는 경우 새로운 Holding 생성 후 매수 처리")
+    void processBuyOrderCreateNewHolding() {
+        // given
+        Holding newHolding = Holding.builder()
+                .stockCount(0)
+                .averagePrice(0L)
+                .build();
+        given(tradeReservationService.readByStockCode("005390")).willReturn(List.of(buyReservation));
+        given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
+        given(holdingService.readByUserIdAndStockCode(1L, "005390")).willReturn(Optional.empty());
+        given(userService.readById(1L)).willReturn(Optional.of(user));
+        given(holdingService.save(any(Holding.class))).willReturn(newHolding);
+
+        // when
+        tradeReservationTrigger.processTradeReservations("005390", 2900L);
+
+        // then
+        assertEquals(buyReservation.getStockCount(), newHolding.getStockCount());
+        assertEquals(buyReservation.getInputPrice(), newHolding.getAveragePrice());
+
+        verify(holdingService, times(1)).save(any(Holding.class));
+        verify(tradeReservationService, times(1)).deleteById(buyReservation.getId());
+        verify(tradeService, times(1)).save(any(Trade.class));
+    }
+
+    @Test
+    @DisplayName("매도 후 보유 주식이 0이 되면 삭제")
+    void processSellOrderDeleteHoldingWhenZero() {
+        // given
+        TradeReservation fullSellReservation = TradeReservation.builder()
+                .tradeType(TradeType.SELL)
+                .inputPrice(3000L)
+                .stockCount(10)
+                .stockName("삼성전자")
+                .stockCode("005390")
+                .userId(1L)
+                .build();
+
+        given(tradeReservationService.readByStockCode("005390")).willReturn(List.of(fullSellReservation));
+        given(accountService.readByUserId(1L)).willReturn(Optional.of(account));
+        given(holdingService.readByUserIdAndStockCode(1L, "005390")).willReturn(Optional.of(holding));
+        long expectedBalance = account.getBalance() + (fullSellReservation.getInputPrice() * fullSellReservation.getStockCount());
+
+        // when
+        tradeReservationTrigger.processTradeReservations("005390", 3100L);
+
+        // then
+        assertEquals(expectedBalance, account.getBalance());
+
+        verify(holdingService, times(1)).deleteByUserIdAndStockCode(1L, "005390");
+        verify(tradeReservationService, times(1)).deleteById(fullSellReservation.getId());
+        verify(tradeService, times(1)).save(any(Trade.class));
+    }
+}


### PR DESCRIPTION
## 배경
- close #60 

## 작업 사항
- 예약 분기별 성공 로직 구현
- 관련 테스트 코드 작성

## 추가 논의
- 짜면서 아쉬웠던 점은 이전에 `StockTradeExecutor`와 합쳐 로직을 진행하고자 하였으나, 예외값 확인하는 로직 및 몇몇개의 로직에서 차이점이 있어 사용하지 못했습니다. 그래서, 코드가 복잡해 보일 수 있다고 생각하는데 확인해주시길 바랍니다!
- 서버 내에서 실행되는 로직이고, 처리 속도를 높이기 위해 비동기를 사용했습니다. 이 로직에서 비동기가 적절할까? 라는 생각이 드는데 어떻게 생각하시나요? (만약 예약된 주식의 종류가 많아진다면, 쓰레드풀을 설정해야할 듯)