### PR TITLE
Feature: 스케줄링 전용 쓰레드풀 설정

### DIFF
--- a/src/main/java/muzusi/infrastructure/config/SchedulingConfig.java
+++ b/src/main/java/muzusi/infrastructure/config/SchedulingConfig.java
@@ -1,9 +1,22 @@
 package muzusi.infrastructure.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
 @EnableScheduling
 public class SchedulingConfig {
+    private final static int THREAD_POOL_SIZE = 3;
+
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(THREAD_POOL_SIZE);
+        taskScheduler.setThreadNamePrefix("Scheduling-thread-");
+        taskScheduler.initialize();
+        return taskScheduler;
+    }
 }


### PR DESCRIPTION
## 배경
- #72 

## 작업 사항
- `SchedulingConfig` 내 쓰레드풀 설정 코드 추가

## 테스트 결과
![image](https://github.com/user-attachments/assets/54890abc-87fc-45d9-8417-e482e9395ed6)

## 기타
스케줄링 시 기본적으로 `SimpleAsyncTaskScheduler`를 적용하여 단일 쓰레드로 동작한다는 것을 알게되었습니다.

스케줄링 쓰레드풀 적용 방법 관련하여 
[스프링 공식문서](https://docs.spring.io/spring-framework/reference/integration/scheduling.html#scheduling-task-scheduler)에서는 `TaskScheduler`를 커스터마이징한 Bean을 등록할 수 있다고 되어있습니다.

[스프링부트 공식문서](https://docs.spring.io/spring-boot/reference/features/task-execution-and-scheduling.html)에서는yaml 파일에서  name space를 통해 자동 설정 가능하도록 지원한다고 되었습니다. 
> 스프링부트 패키지 내 설정 파일: `TaskSchedulingProperties`


두 방법 중 `TaskScheduler`를 커스텀하여 Bean으로 등록하는 방법을 선택한 이유는 아래와 같습니다.
- 코드 내에 쓰레드풀 설정에 대한 명시적 표현
- 쓰레드풀 사이즈 설정 관련하여 추가 코드(`Runtime.getRuntime().availableProcessors()` 등)를 통해 유연한 대응 가능

---

그리고, 몇몇 블로그들에서 `TaskScheduler` 빈 등록 후, 스케줄링 작업 메서드에 `@Async("taskScheduler")` 어노테이션을 사용하여 적용하는 경우를 보았습니다.
해당 방법은 쓰레드풀 사이즈 설정에 관한 문제는 없으나, 메서드 실행 시 비동기적으로 호출되어 `Threed.sleep()`을 넣더라도 계속해서 추가 쓰레드로 할당되어 작업이 진행되는 문제를 발견하여 해당 방법은 잘못된 방법 같습니다.
해당 사항 관련하여 궁금하신 부분 있다면 연락 부탁드립니다!

## 추가 논의

추가적으로, 현재 쓰레드풀 사이즈 관련하여
- 네이버 뉴스 API 호출
- 한국투자증권 주신 순위 API 호출
- 한국투자증권 현재가 조회 API 호출 (예약 체결)

와 같은 작업들을 고려하여 쓰레드풀 사이즈를 3으로 설정하였습니다.