### PR TITLE
Feature: 예약한 주식 정보 반환 기능 추가

### DIFF
--- a/src/main/java/muzusi/application/trade/dto/ReservationInfoDto.java
+++ b/src/main/java/muzusi/application/trade/dto/ReservationInfoDto.java
@@ -1,0 +1,26 @@
+package muzusi.application.trade.dto;
+
+import muzusi.domain.trade.entity.TradeReservation;
+import muzusi.domain.trade.type.TradeType;
+
+import java.time.LocalDateTime;
+
+public record ReservationInfoDto(
+        String id,
+        Long userId,
+        Long inputPrice,
+        Integer stockCount,
+        String stockName,
+        String stockCode,
+        TradeType tradeType,
+        LocalDateTime createdAt
+) {
+    public static ReservationInfoDto fromEntity(TradeReservation tradeReservation) {
+        return new ReservationInfoDto(
+                tradeReservation.getId(), tradeReservation.getUserId(),
+                tradeReservation.getInputPrice(), tradeReservation.getStockCount(),
+                tradeReservation.getStockName(), tradeReservation.getStockCode(),
+                tradeReservation.getTradeType(), tradeReservation.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/muzusi/application/trade/service/UserTradeReservationService.java
+++ b/src/main/java/muzusi/application/trade/service/UserTradeReservationService.java
@@ -1,0 +1,22 @@
+package muzusi.application.trade.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.trade.dto.ReservationInfoDto;
+import muzusi.domain.trade.service.TradeReservationService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserTradeReservationService {
+    private final TradeReservationService tradeReservationService;
+
+    @Transactional(readOnly = true)
+    public List<ReservationInfoDto> getReservationsByUserId(Long userId) {
+        return tradeReservationService.readByUserId(userId)
+                .stream().map(ReservationInfoDto::fromEntity)
+                .toList();
+    }
+}

--- a/src/main/java/muzusi/domain/trade/repository/TradeReservationRepository.java
+++ b/src/main/java/muzusi/domain/trade/repository/TradeReservationRepository.java
@@ -2,9 +2,13 @@ package muzusi.domain.trade.repository;
 
 import muzusi.domain.trade.entity.TradeReservation;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 import java.util.List;
 
 public interface TradeReservationRepository extends MongoRepository<TradeReservation, String> {
     List<TradeReservation> findByStockCode(String stockCode);
+
+    @Query(value = "{ 'userId': ?0 }", sort = "{ 'createdAt': -1 }")
+    List<TradeReservation> findByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/muzusi/domain/trade/service/TradeReservationService.java
+++ b/src/main/java/muzusi/domain/trade/service/TradeReservationService.java
@@ -29,6 +29,10 @@ public class TradeReservationService {
         return tradeReservationRepository.findByStockCode(stockCode);
     }
 
+    public List<TradeReservation> readByUserId(Long userId) {
+        return tradeReservationRepository.findByUserIdOrderByCreatedAtDesc(userId);
+    }
+
     public void deleteById(String id) {
         tradeReservationRepository.deleteById(id);
     }

--- a/src/main/java/muzusi/presentation/trade/api/TradeReservationApi.java
+++ b/src/main/java/muzusi/presentation/trade/api/TradeReservationApi.java
@@ -1,0 +1,63 @@
+package muzusi.presentation.trade.api;
+
+import api.link.checker.annotation.ApiGroup;
+import api.link.checker.annotation.TrackApi;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import muzusi.global.security.auth.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@ApiGroup(value = "[예약 내역 API]")
+@Tag(name = "[예약 내역 API]", description = "예약 내역 관련 API")
+public interface TradeReservationApi {
+
+    @TrackApi(description = "예약 내역 불러오기")
+    @Operation(summary = "예약 내역 불러오기", description = "예약 내을를 불러오는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "예약 내역 불러오기 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "code": 200,
+                                            "message": "요청이 성공하였습니다.",
+                                            "data": {
+                                                "content": [
+                                                    {
+                                                        "id": "67a34d7f69fde23d0c0bef59",
+                                                        "userId": 22,
+                                                        "inputPrice": 55000,
+                                                        "stockCount": 10,
+                                                        "stockName": "삼성전자",
+                                                        "stockCode": "005930",
+                                                        "tradeType": "BUY",
+                                                        "createdAt": "2025-02-05T14:37:35.249"
+                                                    },
+                                                    {
+                                                        "id": "67a34d7f69fde23d0c0bef59",
+                                                        "userId": 22,
+                                                        "inputPrice": 250000,
+                                                        "stockCount": 10,
+                                                        "stockName": "NAVER",
+                                                        "stockCode": "035420",
+                                                        "tradeType": "SELL",
+                                                        "createdAt": "2025-02-05T12:32:30.582"
+                                                    }
+                                                ],
+                                                "page": {
+                                                    "size": 10,
+                                                    "number": 0,
+                                                    "totalElements": 2,
+                                                    "totalPages": 1
+                                                }
+                                            }
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getAllReservations(@AuthenticationPrincipal CustomUserDetails userDetails);
+}

--- a/src/main/java/muzusi/presentation/trade/controller/TradeReservationController.java
+++ b/src/main/java/muzusi/presentation/trade/controller/TradeReservationController.java
@@ -1,0 +1,25 @@
+package muzusi.presentation.trade.controller;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.trade.service.UserTradeReservationService;
+import muzusi.global.response.success.SuccessResponse;
+import muzusi.global.security.auth.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/trades")
+@RequiredArgsConstructor
+public class TradeReservationController {
+    private final UserTradeReservationService userTradeReservationService;
+
+    @GetMapping("/reservations")
+    public ResponseEntity<?> getAllReservations(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(
+                SuccessResponse.from(userTradeReservationService.getReservationsByUserId(userDetails.getUserId()))
+        );
+    }
+}

--- a/src/main/java/muzusi/presentation/trade/controller/TradeReservationController.java
+++ b/src/main/java/muzusi/presentation/trade/controller/TradeReservationController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import muzusi.application.trade.service.UserTradeReservationService;
 import muzusi.global.response.success.SuccessResponse;
 import muzusi.global.security.auth.CustomUserDetails;
+import muzusi.presentation.trade.api.TradeReservationApi;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,9 +14,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/trades")
 @RequiredArgsConstructor
-public class TradeReservationController {
+public class TradeReservationController implements TradeReservationApi {
     private final UserTradeReservationService userTradeReservationService;
 
+    @Override
     @GetMapping("/reservations")
     public ResponseEntity<?> getAllReservations(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok(


### PR DESCRIPTION
## 배경
사용자가 예약한 내역을 조회가 필요 - 확인 및 취소를 위함

## 작업 사항
- 예약 주식 정보 반환

## 추가 논의
얘기를 나눈 것처럼 전체 내역 조회만 구현하였습니다. 후에 필요시, 종목에 대한 예약 내역 추가하겠습니다

## 테스트
<img width="644" alt="스크린샷 2025-02-05 오후 8 37 53" src="https://github.com/user-attachments/assets/0a77aed5-5b8d-42bf-8d8c-e3c1b6b98411" />
