### PR TITLE
Feature: 주식 분봉 데이터 저장

### DIFF
--- a/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
+++ b/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
@@ -29,13 +29,10 @@ public class KisScheduler {
         kisOAuthService.saveWebSocketKey();
     }
 
-    @Scheduled(cron = "0 0/10 9-14 * * 1-5")
-    public void runRankingJob() {
-        kisRankingService.saveVolumeRank();
-        kisRankingService.saveFluctuationRank();
-    }
-
-    @Scheduled(cron = "0 10,20,30 15 * * 1-5")
+    @Schedules({
+            @Scheduled(cron = "0 0/10 9-14 * * 1-5"),
+            @Scheduled(cron = "0 10,20,30 15 * * 1-5")
+    })
     public void runRankingJobAt3PM() {
         kisRankingService.saveVolumeRank();
         kisRankingService.saveFluctuationRank();

--- a/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
+++ b/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
@@ -3,14 +3,21 @@ package muzusi.application.kis.scheduler;
 import lombok.RequiredArgsConstructor;
 import muzusi.application.kis.service.KisOAuthService;
 import muzusi.application.kis.service.KisRankingService;
+import muzusi.application.kis.service.KisStockService;
+import muzusi.domain.stock.service.StockMinutesService;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.annotation.Schedules;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
 
 @Component
 @RequiredArgsConstructor
 public class KisScheduler {
     private final KisOAuthService kisOAuthService;
     private final KisRankingService kisRankingService;
+    private final KisStockService kisStockService;
+    private final StockMinutesService stockMinutesService;
 
     @Scheduled(cron = "0 0 7 * * ?")
     public void runIssueAccessTokenJob() {
@@ -32,5 +39,20 @@ public class KisScheduler {
     public void runRankingJobAt3PM() {
         kisRankingService.saveVolumeRank();
         kisRankingService.saveFluctuationRank();
+    }
+
+    @Schedules({
+            @Scheduled(cron = "0 10,20,30,40,50 9 * * 1-5"),
+            @Scheduled(cron = "0 0/10 10-14 * * 1-5"),
+            @Scheduled(cron = "0 0,10,20,30 15 * * 1-5")
+    })
+    public void runSaveStockMinutesChart() throws InterruptedException {
+        kisStockService.saveStockMinutesChart();
+    }
+
+    @Scheduled(cron = "0 0 16 * * 1-5")
+    public void runSaveDailyStockMinutesChartJob() {
+        kisStockService.saveDailyStockMinutesChart();
+        stockMinutesService.deleteByDateBefore(LocalDate.now().minusDays(6));
     }
 }

--- a/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
+++ b/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
@@ -31,7 +31,7 @@ public class KisScheduler {
 
     @Schedules({
             @Scheduled(cron = "0 0/10 9-14 * * 1-5"),
-            @Scheduled(cron = "0 10,20,30 15 * * 1-5")
+            @Scheduled(cron = "0 0,10,20,30 15 * * 1-5")
     })
     public void runRankingJobAt3PM() {
         kisRankingService.saveVolumeRank();

--- a/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
+++ b/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
@@ -3,7 +3,7 @@ package muzusi.application.kis.scheduler;
 import lombok.RequiredArgsConstructor;
 import muzusi.application.kis.service.KisOAuthService;
 import muzusi.application.kis.service.KisRankingService;
-import muzusi.application.kis.service.KisStockService;
+import muzusi.application.kis.service.KisStockMinutesService;
 import muzusi.domain.stock.service.StockMinutesService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.scheduling.annotation.Schedules;
@@ -16,7 +16,7 @@ import java.time.LocalDate;
 public class KisScheduler {
     private final KisOAuthService kisOAuthService;
     private final KisRankingService kisRankingService;
-    private final KisStockService kisStockService;
+    private final KisStockMinutesService kisStockMinutesService;
     private final StockMinutesService stockMinutesService;
 
     @Scheduled(cron = "0 0 7 * * ?")
@@ -44,12 +44,12 @@ public class KisScheduler {
             @Scheduled(cron = "0 0,10,20,30 15 * * 1-5")
     })
     public void runSaveStockMinutesChart() throws InterruptedException {
-        kisStockService.saveStockMinutesChart();
+        kisStockMinutesService.saveStockMinutesChart();
     }
 
     @Scheduled(cron = "0 0 16 * * 1-5")
     public void runSaveDailyStockMinutesChartJob() {
-        kisStockService.saveDailyStockMinutesChart();
+        kisStockMinutesService.saveDailyStockMinutesChart();
         stockMinutesService.deleteByDateBefore(LocalDate.now().minusDays(6));
     }
 }

--- a/src/main/java/muzusi/application/kis/service/KisStockMinutesService.java
+++ b/src/main/java/muzusi/application/kis/service/KisStockMinutesService.java
@@ -19,7 +19,7 @@ import java.util.List;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class KisStockService {
+public class KisStockMinutesService {
     private final StockCodeProvider stockCodeProvider;
     private final RedisService redisService;
     private final KisStockClient kisStockClient;

--- a/src/main/java/muzusi/application/kis/service/KisStockService.java
+++ b/src/main/java/muzusi/application/kis/service/KisStockService.java
@@ -2,13 +2,19 @@ package muzusi.application.kis.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import muzusi.application.stock.dto.StockMinutesChartInfoDto;
+import muzusi.domain.stock.entity.StockMinutes;
+import muzusi.domain.stock.service.StockMinutesService;
 import muzusi.infrastructure.data.StockCodeProvider;
 import muzusi.infrastructure.kis.KisStockClient;
 import muzusi.infrastructure.redis.RedisService;
 import muzusi.infrastructure.redis.constant.KisConstant;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
 
 @Slf4j
 @Component
@@ -17,6 +23,7 @@ public class KisStockService {
     private final StockCodeProvider stockCodeProvider;
     private final RedisService redisService;
     private final KisStockClient kisStockClient;
+    private final StockMinutesService stockMinutesService;
 
     public void saveStockMinutesChart() throws InterruptedException {
         int count = 0;
@@ -26,6 +33,20 @@ public class KisStockService {
                 Thread.sleep(1000L);
             }
             redisService.setList(KisConstant.MINUTES_CHART_PREFIX.getValue() + ":" + code, kisStockClient.getStockMinutesChartInfo(code, now));
+        }
+    }
+
+    public void saveDailyStockMinutesChart() {
+        for (String code : stockCodeProvider.getAllStockCodes()) {
+            List<StockMinutesChartInfoDto> minutesChars = redisService.getList(KisConstant.MINUTES_CHART_PREFIX.getValue() + ":" + code).stream()
+                            .map(stockMinutesChart -> (StockMinutesChartInfoDto) stockMinutesChart)
+                            .toList();
+
+            stockMinutesService.save(StockMinutes.builder()
+                    .stockCode(code)
+                    .date(LocalDate.now(ZoneId.of("Asia/Seoul")))
+                    .minutesChart(minutesChars)
+                    .build());
         }
     }
 }

--- a/src/main/java/muzusi/domain/stock/entity/StockMinutes.java
+++ b/src/main/java/muzusi/domain/stock/entity/StockMinutes.java
@@ -1,0 +1,33 @@
+package muzusi.domain.stock.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import muzusi.application.stock.dto.StockMinutesChartInfoDto;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "stock_minutes")
+public class StockMinutes {
+    @Id
+    private String id;
+
+    private String stockCode;
+
+    private LocalDate date;
+
+    private List<StockMinutesChartInfoDto> minutesChart;
+
+    @Builder
+    public StockMinutes(String stockCode, LocalDate date, List<StockMinutesChartInfoDto> minutesChart) {
+        this.stockCode = stockCode;
+        this.date = date;
+        this.minutesChart = minutesChart;
+    }
+}

--- a/src/main/java/muzusi/domain/stock/repository/StockMinutesRepository.java
+++ b/src/main/java/muzusi/domain/stock/repository/StockMinutesRepository.java
@@ -1,12 +1,12 @@
 package muzusi.domain.stock.repository;
 
 import muzusi.domain.stock.entity.StockMinutes;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.time.LocalDate;
 import java.util.List;
 
-public interface StockMinutesRepository extends CrudRepository<StockMinutes, Integer> {
+public interface StockMinutesRepository extends MongoRepository<StockMinutes, String> {
     List<StockMinutes> findByStockCodeOrderByDateAsc(String stockCode);
 
     void deleteByDateBefore(LocalDate date);

--- a/src/main/java/muzusi/domain/stock/repository/StockMinutesRepository.java
+++ b/src/main/java/muzusi/domain/stock/repository/StockMinutesRepository.java
@@ -1,0 +1,13 @@
+package muzusi.domain.stock.repository;
+
+import muzusi.domain.stock.entity.StockMinutes;
+import org.springframework.data.repository.CrudRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface StockMinutesRepository extends CrudRepository<StockMinutes, Integer> {
+    List<StockMinutes> findByStockCodeOrderByDateAsc(String stockCode);
+
+    void deleteByDateBefore(LocalDate date);
+}

--- a/src/main/java/muzusi/domain/stock/service/StockMinutesService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockMinutesService.java
@@ -18,6 +18,10 @@ public class StockMinutesService {
         stockMinutesRepository.save(stockMinutes);
     }
 
+    public void saveAll(List<StockMinutes> stockMinutesList) {
+        stockMinutesRepository.saveAll(stockMinutesList);
+    }
+
     public List<StockMinutes> readByStockCode(String stockCode) {
         return stockMinutesRepository.findByStockCodeOrderByDateAsc(stockCode);
     }

--- a/src/main/java/muzusi/domain/stock/service/StockMinutesService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockMinutesService.java
@@ -1,0 +1,28 @@
+package muzusi.domain.stock.service;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.stock.entity.StockMinutes;
+import muzusi.domain.stock.repository.StockMinutesRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StockMinutesService {
+    private final StockMinutesRepository stockMinutesRepository;
+
+    public void save(StockMinutes stockMinutes) {
+        stockMinutesRepository.save(stockMinutes);
+    }
+
+    public List<StockMinutes> readByStockCode(String stockCode) {
+        return stockMinutesRepository.findByStockCodeOrderByDateAsc(stockCode);
+    }
+
+    public void deleteByDateBefore(LocalDate date) {
+        stockMinutesRepository.deleteByDateBefore(date);
+    }
+}


### PR DESCRIPTION
## 배경
- #80 

## 작업 사항
- 9시 10분~15시 30분동안 10분마다 한국투자증권 주식 분봉 데이터 호출 및 Redis 내 저장
- 16시에 Redis → MongoDB 데이터 이관 및 삭제

## 테스트 결과

### Redis
![redis](https://github.com/user-attachments/assets/aa322fd4-0d3c-4fdd-80e9-df9cd98aa3a1)

### MongoDB
![mongo](https://github.com/user-attachments/assets/3d4a7068-ae52-4fdc-a138-d830e9908c8d)



## 추가 논의

### 1. MongoDB 내 데이터 삽입 시 ISODate 사용으로 인하여 시간 오차 발생
해당 부분은 값 저장 시에만 영국시간에 맞춰서 저장된다고 합니다. 값을 꺼내서 사용할 때는 다시 한국 시간만큼 시차가 더해져서 출력되기 때문에 문제가 없는 것 같습니다.
![mongo-result](https://github.com/user-attachments/assets/149172ea-d59f-42c2-8df1-b7e235cf7873)

### 2. 주식 분봉 데이터 저장에 걸리는 시간에 따른 유의 사항
주식 분봉 데이터는 10분 단위로 저장을 합니다.
9:10분에 한국투자증권 API를 호출하여 9:00~10분 데이터를 저장합니다. 

모든 주식 정보에 대해서 API를 호출하기 때문에 저장하는데 5분 내외의 시간이 소요됩니다.
따라서 9:00~9:10분의 분봉은 9:15분 이후에 조회가 가능할 것 같습니다.

(@gugitgugit ) 해당 부분을 고려하였을 때 가장 최근 분봉은 프론트에서 웹 소켓을 통하여 보여주는 방식을 선택해야 할 것 같습니다.
다른 의견이 있다면 다같이 이야기 나눠보면 좋을 것 같습니다!

### 3. 클래스명 및 패키지 구조
현재 `KisStockService`에 주식 분봉 데이터 저장 메서드들을 구현한 상태입니다.
해당 부분 관련해서 클래스명이 이것이 맞을까, 구조는 이게 맞을까라는  의문이 들기도 하였습니다.
다른 적절한 의견이 있으시다면 코멘트 부탁드리겠습니다!

또한, [`KisScheduler.runSaveDailyStockMinutesChartJob()`](https://github.com/Team-Digimon/muzusi-was/blob/a51f3bdefdf367e98602f8d561236ef2ae12e842/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java#L53)에서 비지니스 로직을 수행하는 서비스 클래스가 아닌, StockMinutes 도메인 직접 조작에 관한 서비스 클래스인 `StockMinutesService`를 주입받아 사용했습니다. 혹시나 어떻게 생각하시는 지 궁금합니다!

### 4. Redis 해킹 (기타)
이는 전에도 말씀드렸던 문제이긴 하나, 저만 발생하는 문제 같기는 합니다.
혹시라도 테스트할 시에 Redis 내 데이터가 모두 삭제되고 backup 파일만 남는 현상이 발생한다면 도움 드릴 수 있을 것 같습니다!