### PR TITLE
Feature: 주식 현재가 저장

### DIFF
--- a/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
+++ b/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
@@ -44,7 +44,7 @@ public class KisScheduler {
             @Scheduled(cron = "0 0,10,20,30 15 * * 1-5")
     })
     public void runSaveStockMinutesChart() throws InterruptedException {
-        kisStockMinutesService.saveStockMinutesChart();
+        kisStockMinutesService.saveStockMinutesChartAndInquirePrice();
     }
 
     @Scheduled(cron = "0 0 16 * * 1-5")

--- a/src/main/java/muzusi/application/kis/service/KisStockMinutesService.java
+++ b/src/main/java/muzusi/application/kis/service/KisStockMinutesService.java
@@ -76,7 +76,9 @@ public class KisStockMinutesService {
     private StockPriceDto extractStockPrice(StockMinutesChartInfoDto stockMinutesChartInfo) {
         return StockPriceDto.builder()
                 .stockCode(stockMinutesChartInfo.stockCode())
-                .price(stockMinutesChartInfo.close())
+                .low(stockMinutesChartInfo.low())
+                .high(stockMinutesChartInfo.high())
+                .close(stockMinutesChartInfo.close())
                 .build();
     }
 

--- a/src/main/java/muzusi/application/kis/service/KisStockMinutesService.java
+++ b/src/main/java/muzusi/application/kis/service/KisStockMinutesService.java
@@ -69,6 +69,7 @@ public class KisStockMinutesService {
             if (++count == BATCH_SIZE) {
                stockMinutesService.saveAll(stockMinutesList);
                stockMinutesList.clear();
+               count = 0;
             }
         }
 

--- a/src/main/java/muzusi/application/kis/service/KisStockMinutesService.java
+++ b/src/main/java/muzusi/application/kis/service/KisStockMinutesService.java
@@ -35,7 +35,7 @@ public class KisStockMinutesService {
     /**
      * 한국투자증권 주식 분봉데이터 호출 및 저장 메서드.
      *
-     * REST API 호출 유량 제한으로 인하여 초당 20개 단위 주식 데이터 호출 제한
+     * REST API 호출 유량 제한으로 인하여 초당 15개 단위 주식 데이터 호출 제한
      */
     public void saveStockMinutesChartAndInquirePrice() throws InterruptedException {
         int count = 0;

--- a/src/main/java/muzusi/application/stock/dto/StockPriceDto.java
+++ b/src/main/java/muzusi/application/stock/dto/StockPriceDto.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 @Builder
 public record StockPriceDto(
         String stockCode,
-        long price
+        Long close,
+        Long low,
+        Long high
 ) {
 }

--- a/src/main/java/muzusi/application/stock/dto/StockPriceDto.java
+++ b/src/main/java/muzusi/application/stock/dto/StockPriceDto.java
@@ -1,21 +1,10 @@
 package muzusi.application.stock.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import lombok.Builder;
-
-import java.time.LocalDateTime;
 
 @Builder
 public record StockPriceDto(
-        String code,
-        long price,
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-        @JsonSerialize(using = LocalDateTimeSerializer.class)
-        LocalDateTime time
+        String stockCode,
+        long price
 ) {
 }

--- a/src/main/java/muzusi/infrastructure/config/RedisConfig.java
+++ b/src/main/java/muzusi/infrastructure/config/RedisConfig.java
@@ -36,7 +36,9 @@ public class RedisConfig {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer() );
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         return redisTemplate;
     }

--- a/src/main/java/muzusi/infrastructure/redis/RedisService.java
+++ b/src/main/java/muzusi/infrastructure/redis/RedisService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 @Service
@@ -51,5 +52,9 @@ public class RedisService {
 
     public Set<Object> getSetMembers(String key) {
         return redisTemplate.opsForSet().members(key);
+    }
+
+    public void addToHash(String key, Map<String, Object> value) {
+        redisTemplate.opsForHash().putAll(key, value);
     }
 }

--- a/src/main/java/muzusi/infrastructure/redis/constant/KisConstant.java
+++ b/src/main/java/muzusi/infrastructure/redis/constant/KisConstant.java
@@ -14,6 +14,7 @@ public enum KisConstant {
     VOLUME_RANK_TIME_PREFIX("kis:volume-rank-time"),
     FLUCTUATION_RANK_TIME_PREFIX("kis:fluctuation-rank-time"),
     MINUTES_CHART_PREFIX("kis:minutes-chart"),
+    INQUIRE_PRICE_PREFIX("kis:inquire-price"),
     ;
 
     private final String value;


### PR DESCRIPTION
## 배경
- #82 

## 작업 사항
- 주식 분봉데이터 종가(close) 기준 현재가 저장
   - Redis Hash 사용으로 인한 Hash Serializer/Deserializer 설정 추가

## 결과

![inquire-price](https://github.com/user-attachments/assets/39437946-1866-41b7-a32c-caadf9bc03ca)

hash내 현재가 값이 최근 분봉 데이터 종가 값과 동일합니다.
> 위 사진에서 분봉 데이터 1,2는 중복된 값이라 해당 부분은 무시해주셔도 될 것 같습니다.