### PR TITLE
Feature: 예약 내역 확인 처리 스케줄링 적용

### DIFF
--- a/src/main/java/muzusi/application/trade/scheduler/TradeScheduler.java
+++ b/src/main/java/muzusi/application/trade/scheduler/TradeScheduler.java
@@ -2,16 +2,28 @@ package muzusi.application.trade.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import muzusi.application.trade.service.TradeReservationCleaner;
+import muzusi.application.trade.service.TradeReservationTrigger;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.annotation.Schedules;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class TradeScheduler {
     private final TradeReservationCleaner tradeReservationCleaner;
+    private final TradeReservationTrigger tradeReservationTrigger;
 
-    @Scheduled(cron = "0 30 15 * * MON-FRI")
+    @Scheduled(cron = "0 30 15 * * 1-5")
     public void runReservationDeleteJob() {
         tradeReservationCleaner.clearReservedOrdersAtMarketClose();
+    }
+
+    @Schedules({
+            @Scheduled(cron = "0 15,25,35,45,55 9 * * 1-5"),
+            @Scheduled(cron = "0 5,15,25,35,45,55 10-14 * * 1-5"),
+            @Scheduled(cron = "0 5,15,25 15 * * 1-5")
+    })
+    public void runReservationTriggerJob() {
+        tradeReservationTrigger.triggerTradeReservations();
     }
 }

--- a/src/main/java/muzusi/application/trade/service/TradeReservationProcessor.java
+++ b/src/main/java/muzusi/application/trade/service/TradeReservationProcessor.java
@@ -42,8 +42,8 @@ public class TradeReservationProcessor {
      * 1. 예약 매수/매도 별 userId로 구분하여 값 수집 (예약 체결 가능한 값)
      * 2. 예약 체결 분기별 처리
      *
-     * @param stockCode  : 주식 코드
-     * @param lowPrice : 특정 시간대 주식 저가
+     * @param stockCode : 주식 코드
+     * @param lowPrice  : 특정 시간대 주식 저가
      * @param highPrice : 특정 시간대 주식 고가
      */
     @Transactional
@@ -63,7 +63,7 @@ public class TradeReservationProcessor {
      * @param stockCode : 주식 코드
      * @param lowPrice : 특정 시간대 주식 저가
      * @param highPrice : 특정 시간대 주식 고가
-     * @return
+     * @return : userId별 매수/매도 Pair 쌍
      */
     private Pair<Map<Long, List<TradeReservation>>, Map<Long, List<TradeReservation>>>
     calculateTotalAmounts(

--- a/src/main/java/muzusi/application/trade/service/TradeReservationProcessor.java
+++ b/src/main/java/muzusi/application/trade/service/TradeReservationProcessor.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
-public class TradeReservationTrigger {
+public class TradeReservationProcessor {
     private final TradeReservationService tradeReservationService;
     private final AccountService accountService;
     private final HoldingService holdingService;

--- a/src/main/java/muzusi/application/trade/service/TradeReservationTrigger.java
+++ b/src/main/java/muzusi/application/trade/service/TradeReservationTrigger.java
@@ -26,7 +26,9 @@ public class TradeReservationTrigger {
                 .forEach(stockCode -> {
                     StockPriceDto stockPriceDto =
                             (StockPriceDto) redisService.getHash(KisConstant.INQUIRE_PRICE_PREFIX.getValue(), stockCode);
-                    tradeReservationProcessor.processTradeReservations(stockCode, stockPriceDto.low(), stockPriceDto.high());
+
+                    if (stockPriceDto != null)
+                        tradeReservationProcessor.processTradeReservations(stockCode, stockPriceDto.low(), stockPriceDto.high());
                 });
     }
 }

--- a/src/main/java/muzusi/application/trade/service/TradeReservationTrigger.java
+++ b/src/main/java/muzusi/application/trade/service/TradeReservationTrigger.java
@@ -1,0 +1,32 @@
+package muzusi.application.trade.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.stock.dto.StockPriceDto;
+import muzusi.infrastructure.redis.RedisService;
+import muzusi.infrastructure.redis.constant.KisConstant;
+import muzusi.infrastructure.redis.constant.TradeConstant;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TradeReservationTrigger {
+    private final TradeReservationProcessor tradeReservationProcessor;
+    private final RedisService redisService;
+
+    /**
+     * 예약 내역 확인 로직 실행 메서드
+     * 1. 예약 내역이 있는 종목 코드 가져오기.
+     * 2. 해당 종목의 특정 시간대 저가, 고가 가져오기.
+     * 3. 처리.
+     */
+    public void triggerTradeReservations() {
+        redisService.getSetMembers(TradeConstant.RESERVATION_PREFIX.getValue())
+                .stream()
+                .map(Object::toString)
+                .forEach(stockCode -> {
+                    StockPriceDto stockPriceDto =
+                            (StockPriceDto) redisService.getHash(KisConstant.INQUIRE_PRICE_PREFIX.getValue(), stockCode);
+                    tradeReservationProcessor.processTradeReservations(stockCode, stockPriceDto.low(), stockPriceDto.high());
+                });
+    }
+}

--- a/src/main/java/muzusi/infrastructure/redis/RedisService.java
+++ b/src/main/java/muzusi/infrastructure/redis/RedisService.java
@@ -1,7 +1,6 @@
 package muzusi.infrastructure.redis;
 
 import lombok.RequiredArgsConstructor;
-import muzusi.global.exception.CustomException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/muzusi/infrastructure/redis/RedisService.java
+++ b/src/main/java/muzusi/infrastructure/redis/RedisService.java
@@ -1,6 +1,7 @@
 package muzusi.infrastructure.redis;
 
 import lombok.RequiredArgsConstructor;
+import muzusi.global.exception.CustomException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -56,5 +57,9 @@ public class RedisService {
 
     public void addToHash(String key, Map<String, Object> value) {
         redisTemplate.opsForHash().putAll(key, value);
+    }
+
+    public Object getHash(String key, String field) {
+        return redisTemplate.opsForHash().get(key, field);
     }
 }

--- a/src/test/java/muzusi/application/trade/service/TradeReservationProcessorTest.java
+++ b/src/test/java/muzusi/application/trade/service/TradeReservationProcessorTest.java
@@ -129,7 +129,7 @@ class TradeReservationProcessorTest {
                 totalPrice) / expectedCount;
 
         // when
-        tradeReservationProcessor.processTradeReservations("005390", 3000L);
+        tradeReservationProcessor.processTradeReservations("005390", 3000L, 3100L);
 
         // then
         assertEquals(0, account.getReservedPrice());
@@ -157,7 +157,7 @@ class TradeReservationProcessorTest {
         int expectedCount = holding.getStockCount() - totalCount;
 
         // when
-        tradeReservationProcessor.processTradeReservations("005390", 3100L);
+        tradeReservationProcessor.processTradeReservations("005390", 3000L, 3100L);
 
         // then
         assertEquals(expectedBalance, account.getBalance());
@@ -188,7 +188,7 @@ class TradeReservationProcessorTest {
         long averagePrice = totalPrice / totalCount;
 
         // when
-        tradeReservationProcessor.processTradeReservations("005390", 2900L);
+        tradeReservationProcessor.processTradeReservations("005390", 2900L, 3100L);
 
         // then
         assertEquals(totalCount, newHolding.getStockCount());
@@ -220,7 +220,7 @@ class TradeReservationProcessorTest {
         long expectedBalance = account.getBalance() + (fullSellReservation.getInputPrice() * fullSellReservation.getStockCount());
 
         // when
-        tradeReservationProcessor.processTradeReservations("005390", 3100L);
+        tradeReservationProcessor.processTradeReservations("005390", 3000L, 3100L);
 
         // then
         assertEquals(expectedBalance, account.getBalance());

--- a/src/test/java/muzusi/application/trade/service/TradeReservationProcessorTest.java
+++ b/src/test/java/muzusi/application/trade/service/TradeReservationProcessorTest.java
@@ -31,10 +31,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class TradeReservationTriggerTest {
+class TradeReservationProcessorTest {
 
     @InjectMocks
-    private TradeReservationTrigger tradeReservationTrigger;
+    private TradeReservationProcessor tradeReservationProcessor;
 
     @Mock
     private TradeReservationService tradeReservationService;
@@ -129,7 +129,7 @@ class TradeReservationTriggerTest {
                 totalPrice) / expectedCount;
 
         // when
-        tradeReservationTrigger.processTradeReservations("005390", 3000L);
+        tradeReservationProcessor.processTradeReservations("005390", 3000L);
 
         // then
         assertEquals(0, account.getReservedPrice());
@@ -157,7 +157,7 @@ class TradeReservationTriggerTest {
         int expectedCount = holding.getStockCount() - totalCount;
 
         // when
-        tradeReservationTrigger.processTradeReservations("005390", 3100L);
+        tradeReservationProcessor.processTradeReservations("005390", 3100L);
 
         // then
         assertEquals(expectedBalance, account.getBalance());
@@ -188,7 +188,7 @@ class TradeReservationTriggerTest {
         long averagePrice = totalPrice / totalCount;
 
         // when
-        tradeReservationTrigger.processTradeReservations("005390", 2900L);
+        tradeReservationProcessor.processTradeReservations("005390", 2900L);
 
         // then
         assertEquals(totalCount, newHolding.getStockCount());
@@ -220,7 +220,7 @@ class TradeReservationTriggerTest {
         long expectedBalance = account.getBalance() + (fullSellReservation.getInputPrice() * fullSellReservation.getStockCount());
 
         // when
-        tradeReservationTrigger.processTradeReservations("005390", 3100L);
+        tradeReservationProcessor.processTradeReservations("005390", 3100L);
 
         // then
         assertEquals(expectedBalance, account.getBalance());

--- a/src/test/java/muzusi/application/trade/service/TradeReservationTriggerTest.java
+++ b/src/test/java/muzusi/application/trade/service/TradeReservationTriggerTest.java
@@ -62,4 +62,21 @@ class TradeReservationTriggerTest {
         // then
         verify(tradeReservationProcessor, times(1)).processTradeReservations(stockCode, 2900L, 3100L);
     }
+
+    @Test
+    @DisplayName("예약된 종목 코드에 대한 현재가가 없는 경우")
+    void triggerTradeReservationsNoStockPrice() {
+        // given
+        String stockCode = "005930";
+        StockPriceDto stockPriceDto = null;
+
+        given(redisService.getSetMembers(TradeConstant.RESERVATION_PREFIX.getValue())).willReturn(Set.of(stockCode));
+        given(redisService.getHash(KisConstant.INQUIRE_PRICE_PREFIX.getValue(), stockCode)).willReturn(stockPriceDto);
+
+        // when
+        tradeReservationTrigger.triggerTradeReservations();
+
+        // then
+        verify(tradeReservationProcessor, never()).processTradeReservations(any(), any(), any());
+    }
 }

--- a/src/test/java/muzusi/application/trade/service/TradeReservationTriggerTest.java
+++ b/src/test/java/muzusi/application/trade/service/TradeReservationTriggerTest.java
@@ -1,0 +1,65 @@
+package muzusi.application.trade.service;
+
+import muzusi.application.stock.dto.StockPriceDto;
+import muzusi.infrastructure.redis.RedisService;
+import muzusi.infrastructure.redis.constant.KisConstant;
+import muzusi.infrastructure.redis.constant.TradeConstant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TradeReservationTriggerTest {
+
+    @InjectMocks
+    private TradeReservationTrigger tradeReservationTrigger;
+
+    @Mock
+    private TradeReservationProcessor tradeReservationProcessor;
+    @Mock
+    private RedisService redisService;
+
+    @Test
+    @DisplayName("예약된 종목 코드가 없는 경우 트리거 실행 안 됨")
+    void triggerTradeReservationsNoStockCode() {
+        // given
+        given(redisService.getSetMembers(TradeConstant.RESERVATION_PREFIX.getValue())).willReturn(Set.of());
+
+        // when
+        tradeReservationTrigger.triggerTradeReservations();
+
+        // then
+        verify(tradeReservationProcessor, never()).processTradeReservations(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("예약된 종목 코드가 있는 경우 정상 처리")
+    void triggerTradeReservationsWithStockCode() {
+        // given
+        String stockCode = "005930";
+        StockPriceDto stockPriceDto = StockPriceDto.builder()
+                .low(2900L)
+                .high(3100L)
+                .build();
+
+        given(redisService.getSetMembers(TradeConstant.RESERVATION_PREFIX.getValue())).willReturn(Set.of(stockCode));
+        given(redisService.getHash(KisConstant.INQUIRE_PRICE_PREFIX.getValue(), stockCode)).willReturn(stockPriceDto);
+
+        // when
+        tradeReservationTrigger.triggerTradeReservations();
+
+        // then
+        verify(tradeReservationProcessor, times(1)).processTradeReservations(stockCode, 2900L, 3100L);
+    }
+}


### PR DESCRIPTION
## 배경
- 주식 예약 내역에 대한 주기적인 확인을 통해 처리를 해야함.
- 10분 단위로 주식 현재가를 불러와 처리하기에, 예약 내역은 5분부터 시작해 10분단위로 진행.
- 10분 단위로 불러오는 주식 현재가의 저가, 고가를 이용하여 예약 내역 범위 확인.

## 작업 사항
- 스케줄링 적용하여 예약 내역 확인 처리
- 관련 테스트 코드 작성

## 추가 논의
- 현재는 9시는 15분부터, 15시는 5~25분 까지, 나머지는 5~55분에 처리하고 있습니다. 다른 시간에 대한 의견이 있으면 말씀해주세요!