### PR TITLE
Fix: 한국투자증권 주식 분봉 데이터 API 호출 시간 오류 수정

### DIFF
--- a/src/main/java/muzusi/application/kis/service/KisStockMinutesService.java
+++ b/src/main/java/muzusi/application/kis/service/KisStockMinutesService.java
@@ -45,7 +45,7 @@ public class KisStockMinutesService {
             if (++count % 15 == 0) {
                 Thread.sleep(1000L);
             }
-            StockChartInfoDto stockChartInfoDto = kisStockClient.getStockMinutesChartInfo(code, LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth()-1, 9, 10));
+            StockChartInfoDto stockChartInfoDto = kisStockClient.getStockMinutesChartInfo(code, now);
             inquirePriceMap.put(code, stockChartInfoDto);
 
             if (count == BATCH_SIZE) {


### PR DESCRIPTION
## 배경
- 한국투자증권 주식 분봉 데이터 호출 시 테스트 용도 설정 시간 미변경으로 오류 발생

## 작업 사항
- 현재 시간으로 변경

## 추가 논의
- 서버 내 주식 분봉데이터 삭제 후 제가 직접 호출해서 하루 치 넣도록 하겠습니다.