### PR TITLE
Feature: 계좌 일별 수익률 추가 및 반환

### DIFF
--- a/src/main/java/muzusi/application/account/dto/AccountDetailsDto.java
+++ b/src/main/java/muzusi/application/account/dto/AccountDetailsDto.java
@@ -3,6 +3,7 @@ package muzusi.application.account.dto;
 import muzusi.domain.account.entity.Account;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record AccountDetailsDto(
         Long id,
@@ -11,9 +12,10 @@ public record AccountDetailsDto(
         LocalDateTime createdAt,
         double totalRateOfReturn,
         long totalEvaluatedAmount,
-        long totalProfitAmount
+        long totalProfitAmount,
+        List<AccountProfitInfoDto> accountProfits
 ) {
-    public static AccountDetailsDto from(Account account, AccountSummaryDto summary) {
+    public static AccountDetailsDto from(Account account, AccountSummaryDto summary, List<AccountProfitInfoDto> accountProfits) {
         return new AccountDetailsDto(
                 account.getId(),
                 account.getBalance(),
@@ -21,7 +23,8 @@ public record AccountDetailsDto(
                 account.getCreatedAt(),
                 summary.totalRateOfReturn(),
                 summary.totalEvaluatedAmount(),
-                summary.totalProfitAmount()
+                summary.totalProfitAmount(),
+                accountProfits
         );
     }
 }

--- a/src/main/java/muzusi/application/account/dto/AccountProfitInfoDto.java
+++ b/src/main/java/muzusi/application/account/dto/AccountProfitInfoDto.java
@@ -1,0 +1,14 @@
+package muzusi.application.account.dto;
+
+import muzusi.domain.account.entity.AccountProfit;
+
+import java.time.LocalDate;
+
+public record AccountProfitInfoDto(
+        long totalBalance,
+        LocalDate createdAt
+) {
+    public static AccountProfitInfoDto fromEntity(AccountProfit accountProfit) {
+        return new AccountProfitInfoDto(accountProfit.getTotalBalance(), accountProfit.getCreatedAt());
+    }
+}

--- a/src/main/java/muzusi/application/account/scheduler/AccountScheduler.java
+++ b/src/main/java/muzusi/application/account/scheduler/AccountScheduler.java
@@ -1,0 +1,17 @@
+package muzusi.application.account.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.account.service.AccountProfitUpdateExecutor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AccountScheduler {
+    private final AccountProfitUpdateExecutor accountProfitUpdateExecutor;
+
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void runAccountProfitUpdateJob() {
+        accountProfitUpdateExecutor.updateAccountProfitRate();
+    }
+}

--- a/src/main/java/muzusi/application/account/service/AccountProfitUpdateExecutor.java
+++ b/src/main/java/muzusi/application/account/service/AccountProfitUpdateExecutor.java
@@ -1,0 +1,45 @@
+package muzusi.application.account.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.holding.service.UserHoldingService;
+import muzusi.domain.account.entity.AccountProfit;
+import muzusi.domain.account.service.AccountProfitService;
+import muzusi.domain.account.service.AccountService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AccountProfitUpdateExecutor {
+    private final AccountProfitService accountProfitService;
+    private final UserHoldingService userHoldingService;
+    private final AccountService accountService;
+
+    /**
+     * 사용자 계좌의 일일 수익률을 저장하는 메서드
+     * 1. 사용자들의 최신 계좌 불러오기
+     * 2. 사용자 별로 계좌의 총 자산 계산
+     */
+    @Transactional
+    public void updateAccountProfitRate() {
+        List<AccountProfit> accountProfits = new ArrayList<>();
+
+        accountService.readAll()
+                .forEach(account -> {
+                    long evaluatedAmount = userHoldingService
+                            .calculateTotalRateOfReturn(account.getId())
+                            .totalEvaluatedAmount();
+
+                    accountProfits.add(AccountProfit.builder()
+                            .totalBalance(account.getBalance() + evaluatedAmount)
+                            .account(account)
+                            .build()
+                    );
+                });
+
+        accountProfitService.saveAll(accountProfits);
+    }
+}

--- a/src/main/java/muzusi/application/account/service/UserAccountService.java
+++ b/src/main/java/muzusi/application/account/service/UserAccountService.java
@@ -77,7 +77,7 @@ public class UserAccountService {
         Account account = accountService.readByUserId(userId)
                 .orElseThrow(() -> new CustomException(AccountErrorType.NOT_FOUND));
 
-        AccountSummaryDto summaryDto = userHoldingService.calculateTotalRateOfReturn(userId);
+        AccountSummaryDto summaryDto = userHoldingService.calculateTotalRateOfReturn(account.getId());
 
         return AccountDetailsDto.from(account, summaryDto);
     }

--- a/src/main/java/muzusi/application/account/service/UserAccountService.java
+++ b/src/main/java/muzusi/application/account/service/UserAccountService.java
@@ -3,10 +3,13 @@ package muzusi.application.account.service;
 import lombok.RequiredArgsConstructor;
 import muzusi.application.account.dto.AccountDetailsDto;
 import muzusi.application.account.dto.AccountInfoDto;
+import muzusi.application.account.dto.AccountProfitInfoDto;
 import muzusi.application.account.dto.AccountSummaryDto;
 import muzusi.application.holding.service.UserHoldingService;
 import muzusi.domain.account.entity.Account;
+import muzusi.domain.account.entity.AccountProfit;
 import muzusi.domain.account.exception.AccountErrorType;
+import muzusi.domain.account.service.AccountProfitService;
 import muzusi.domain.account.service.AccountService;
 import muzusi.domain.user.entity.User;
 import muzusi.domain.user.exception.UserErrorType;
@@ -25,6 +28,7 @@ import java.util.List;
 public class UserAccountService {
     private final UserService userService;
     private final AccountService accountService;
+    private final AccountProfitService accountProfitService;
     private final AccountManagementService accountManagementService;
     private final UserHoldingService userHoldingService;
 
@@ -77,8 +81,14 @@ public class UserAccountService {
         Account account = accountService.readByUserId(userId)
                 .orElseThrow(() -> new CustomException(AccountErrorType.NOT_FOUND));
 
+        List<AccountProfitInfoDto> accountProfits =
+                accountProfitService.readByAccountId(account.getId())
+                        .stream()
+                        .map(AccountProfitInfoDto::fromEntity)
+                        .toList();
+
         AccountSummaryDto summaryDto = userHoldingService.calculateTotalRateOfReturn(account.getId());
 
-        return AccountDetailsDto.from(account, summaryDto);
+        return AccountDetailsDto.from(account, summaryDto, accountProfits);
     }
 }

--- a/src/main/java/muzusi/application/holding/service/UserHoldingService.java
+++ b/src/main/java/muzusi/application/holding/service/UserHoldingService.java
@@ -46,12 +46,12 @@ public class UserHoldingService {
     /**
      * 보유 종목들에 대한 총 수익률을 계산하는 메서드
      *
-     * @param userId : 사용자 ID
+     * @param accountId : 계좌 ID
      * @return : 총 수익률, 평가금액, 수익금액
      */
     @Transactional(readOnly = true)
-    public AccountSummaryDto calculateTotalRateOfReturn(Long userId) {
-        List<Holding> holdings = holdingService.readByUserId(userId);
+    public AccountSummaryDto calculateTotalRateOfReturn(Long accountId) {
+        List<Holding> holdings = holdingService.readByAccountId(accountId);
         if (holdings.isEmpty()) return AccountSummaryDto.of(0.0, 0, 0);
 
         Map<String, Object> stockPrices = getStockPrices(holdings);

--- a/src/main/java/muzusi/domain/account/entity/AccountProfit.java
+++ b/src/main/java/muzusi/domain/account/entity/AccountProfit.java
@@ -1,0 +1,45 @@
+package muzusi.domain.account.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Entity(name = "account_profit")
+public class AccountProfit {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "total_balance", nullable = false)
+    private Long totalBalance;
+
+    @CreatedDate
+    private LocalDate createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id")
+    private Account account;
+
+    @Builder
+    public AccountProfit(Long totalBalance, Account account) {
+        this.totalBalance = totalBalance;
+        this.account = account;
+    }
+}

--- a/src/main/java/muzusi/domain/account/repository/AccountProfitRepository.java
+++ b/src/main/java/muzusi/domain/account/repository/AccountProfitRepository.java
@@ -1,0 +1,7 @@
+package muzusi.domain.account.repository;
+
+import muzusi.domain.account.entity.AccountProfit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccountProfitRepository extends JpaRepository<AccountProfit, Long> {
+}

--- a/src/main/java/muzusi/domain/account/repository/AccountProfitRepository.java
+++ b/src/main/java/muzusi/domain/account/repository/AccountProfitRepository.java
@@ -1,7 +1,11 @@
 package muzusi.domain.account.repository;
 
 import muzusi.domain.account.entity.AccountProfit;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AccountProfitRepository extends JpaRepository<AccountProfit, Long> {
+    List<AccountProfit> findByAccount_idOrderByCreatedAtAsc(Long accountId, Pageable pageable);
 }

--- a/src/main/java/muzusi/domain/account/repository/AccountRepository.java
+++ b/src/main/java/muzusi/domain/account/repository/AccountRepository.java
@@ -21,4 +21,13 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
             "WHERE a.user_id = :userId " +
             "ORDER BY a.created_at DESC LIMIT 1", nativeQuery = true)
     LocalDateTime findLatestCreatedAt(@Param("userId") Long userId);
+
+    @Query(value = "SELECT * FROM account a " +
+            "WHERE a.id = ( " +
+            "    SELECT a2.id FROM account a2 " +
+            "    WHERE a2.user_id = a.user_id " +
+            "    ORDER BY a2.created_at DESC " +
+            "    LIMIT 1 " +
+            ")", nativeQuery = true)
+    List<Account> findLatestAccountsForAllUsers();
 }

--- a/src/main/java/muzusi/domain/account/service/AccountProfitService.java
+++ b/src/main/java/muzusi/domain/account/service/AccountProfitService.java
@@ -1,0 +1,18 @@
+package muzusi.domain.account.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.account.entity.AccountProfit;
+import muzusi.domain.account.repository.AccountProfitRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AccountProfitService {
+    private final AccountProfitRepository accountProfitRepository;
+
+    public void saveAll(List<AccountProfit> accountProfits) {
+        accountProfitRepository.saveAll(accountProfits);
+    }
+}

--- a/src/main/java/muzusi/domain/account/service/AccountProfitService.java
+++ b/src/main/java/muzusi/domain/account/service/AccountProfitService.java
@@ -3,6 +3,7 @@ package muzusi.domain.account.service;
 import lombok.RequiredArgsConstructor;
 import muzusi.domain.account.entity.AccountProfit;
 import muzusi.domain.account.repository.AccountProfitRepository;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -14,5 +15,9 @@ public class AccountProfitService {
 
     public void saveAll(List<AccountProfit> accountProfits) {
         accountProfitRepository.saveAll(accountProfits);
+    }
+
+    public List<AccountProfit> readByAccountId(Long accountId) {
+        return accountProfitRepository.findByAccount_idOrderByCreatedAtAsc(accountId, PageRequest.of(0, 14));
     }
 }

--- a/src/main/java/muzusi/domain/account/service/AccountService.java
+++ b/src/main/java/muzusi/domain/account/service/AccountService.java
@@ -30,6 +30,10 @@ public class AccountService {
         return accountRepository.findLatestAccount(userId);
     }
 
+    public List<Account> readAll() {
+        return accountRepository.findLatestAccountsForAllUsers();
+    }
+
     public LocalDateTime readCreatedAt(Long userId) {
         return accountRepository.findLatestCreatedAt(userId);
     }

--- a/src/main/java/muzusi/domain/holding/repository/HoldingRepository.java
+++ b/src/main/java/muzusi/domain/holding/repository/HoldingRepository.java
@@ -31,4 +31,6 @@ public interface HoldingRepository extends JpaRepository<Holding, Long> {
             "WHERE account_id = (SELECT id FROM account WHERE user_id = :userId ORDER BY created_at DESC LIMIT 1)",
             nativeQuery = true)
     List<Holding> findLatestAccountAllHolding(@Param("userId") Long userId);
+
+    List<Holding> findByAccount_Id(Long accountId);
 }

--- a/src/main/java/muzusi/domain/holding/service/HoldingService.java
+++ b/src/main/java/muzusi/domain/holding/service/HoldingService.java
@@ -25,6 +25,10 @@ public class HoldingService {
         return holdingRepository.findLatestAccountAllHolding(userId);
     }
 
+    public List<Holding> readByAccountId(Long accountId) {
+        return holdingRepository.findByAccount_Id(accountId);
+    }
+
     public boolean existsByUserIdAndStockCode(Long userId, String stockCode) {
         return holdingRepository.existsByLatestAccountHolding(userId, stockCode) == 1;
     }


### PR DESCRIPTION
## 배경
- 일별 수익 그래프를 위한 일별 수익률 저장 및 반환 필요

## 작업 사항
- 일별 수익률 저장
- 일별 수익률 반환  (14일)

## 추가 논의
- 14일 이후 삭제 내용은 다음 pr에서 진행하겠습니다
- 일별 수익률 저장 메서드에서 `saveAll()`을 선택하였습니다
  1. Id가 `IDENTITY`형식인데 둘 다 쿼리 하나하나 날리지 않나? -> `saveAll()`은 하나의 트랜잭션을 관리하기 때문에 속도가 더 빠름
  2. 배치 인서트 하면 안되나? -> id 저장 방법 변환 or jdbctemplate 사용. but, 100명의 사용자도 없는 이 상황에서는 고려사항이 아니라고 판단.
 라는 저의 생각으로 `saveAll()`을 적용시켰습니다

## 테스트
- 내용은 그냥 임의로 넣은 것이기 때문에 중복된 데이터로 있습니다
<img width="497" alt="스크린샷 2025-02-20 오후 7 33 17" src="https://github.com/user-attachments/assets/4eeae0f5-2b26-4d24-b11b-5f4fd65b48fd" />

