### PR TITLE
Refact: 한국투자증권 REST API 요청 헤더 생성 팩토리 클래스 분리

### DIFF
--- a/src/main/java/muzusi/infrastructure/kis/KisRankingClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisRankingClient.java
@@ -10,7 +10,6 @@ import muzusi.infrastructure.properties.KisProperties;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
@@ -25,10 +24,12 @@ import java.util.Map;
 public class KisRankingClient {
     private final KisProperties kisProperties;
     private final ObjectMapper objectMapper;
-    private final KisAuthProvider kisAuthProvider;
+    private final KisRequestFactory kisRequestFactory;
+    private final static String VOLUME_RANK_TR_ID = "FHPST01710000";
+    private final static String FLUCTUATION_RANK_TR_ID = "FHPST01700000";
 
     public List<StockRankDto> getVolumeRank() {
-        HttpHeaders headers = getHttpHeaders("FHPST01710000");
+        HttpHeaders headers = kisRequestFactory.getHttpHeader(VOLUME_RANK_TR_ID);
 
         String uri = UriComponentsBuilder.fromUriString(kisProperties.getUrl(KisUrlConstant.VOLUME_RANK))
                 .queryParam("FID_COND_MRKT_DIV_CODE", "J")
@@ -84,7 +85,7 @@ public class KisRankingClient {
     }
 
     private List<StockRankDto> getFluctuationRank(String fluctuation) {
-        HttpHeaders headers = getHttpHeaders("FHPST01700000");
+        HttpHeaders headers = kisRequestFactory.getHttpHeader(FLUCTUATION_RANK_TR_ID);
 
         String uri = UriComponentsBuilder.fromUriString(kisProperties.getUrl(KisUrlConstant.FLUCTUATION_RANK))
                 .queryParam("fid_rsfl_rate2", "")
@@ -132,19 +133,6 @@ public class KisRankingClient {
         } catch (Exception e) {
             throw new KisApiException(e);
         }
-    }
-
-    private HttpHeaders getHttpHeaders(String trId) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
-        headers.add("authorization", kisAuthProvider.getAccessToken().getValue());
-        headers.add("appkey", kisProperties.getAppKey());
-        headers.add("appsecret", kisProperties.getAppSecret());
-        headers.add("tr_id", trId);
-        headers.add("custtype", "P");
-
-        return headers;
     }
 
     private List<StockRankDto> getRankStocks(JsonNode node, Map<String, String> body) {

--- a/src/main/java/muzusi/infrastructure/kis/KisRequestFactory.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisRequestFactory.java
@@ -1,0 +1,27 @@
+package muzusi.infrastructure.kis;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.infrastructure.properties.KisProperties;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KisRequestFactory {
+    private final KisAuthProvider kisAuthProvider;
+    private final KisProperties kisProperties;
+
+    public HttpHeaders getHttpHeader(String trId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        headers.add("authorization", kisAuthProvider.getAccessToken().getValue());
+        headers.add("appkey", kisProperties.getAppKey());
+        headers.add("appsecret", kisProperties.getAppSecret());
+        headers.add("tr_id", trId);
+        headers.add("custtype", "P");
+
+        return headers;
+    }
+}

--- a/src/main/java/muzusi/infrastructure/kis/KisStockClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisStockClient.java
@@ -23,16 +23,12 @@ import java.time.format.DateTimeFormatter;
 public class KisStockClient {
     private final KisProperties kisProperties;
     private final ObjectMapper objectMapper;
-    private final KisAuthProvider kisAuthProvider;
+    private final KisRequestFactory kisRequestFactory;
     private static final int MINUTES_GAP = 10;
+    private static final String MINUTES_CHART_TR_ID = "FHKST03010200";
 
     public StockChartInfoDto getStockMinutesChartInfo(String code, LocalDateTime time) {
-        HttpHeaders headers = new HttpHeaders();
-
-        headers.add("authorization", kisAuthProvider.getAccessToken().getValue());
-        headers.add("appkey", kisProperties.getAppKey());
-        headers.add("appsecret", kisProperties.getAppSecret());
-        headers.add("tr_id", "FHKST03010200");
+        HttpHeaders headers = kisRequestFactory.getHttpHeader(MINUTES_CHART_TR_ID);
 
         String uri = UriComponentsBuilder.fromUriString(kisProperties.getUrl(KisUrlConstant.TIME_ITEM_CHART_PRICE))
                 .queryParam("FID_ETC_CLS_CODE", "")


### PR DESCRIPTION
## 배경
- 한국투자증권 REST API 호출 클래스 `Kis___Client` 내 헤더 생성 코드 중복으로 인한 클래스 분리

## 작업 사항
- 헤더 내 포함 필드 통합
- trId를 통한 헤더 생성 메서드 분리

## 추가 논의
- HttpHeaders 객체 생성을 담당하는 클래스를 별도로 둔 심플 팩토리 패턴이라 생각하여 클래스명으로 Factory를 사용하였으나, 클래스명에 관한 고민이 여전히 남은 상태이긴 합니다.