### PR TITLE
Feature: 오래된 계좌 수익률 삭제 로직 구현

### DIFF
--- a/src/main/java/muzusi/application/account/scheduler/AccountScheduler.java
+++ b/src/main/java/muzusi/application/account/scheduler/AccountScheduler.java
@@ -1,17 +1,22 @@
 package muzusi.application.account.scheduler;
 
 import lombok.RequiredArgsConstructor;
-import muzusi.application.account.service.AccountProfitUpdateExecutor;
+import muzusi.application.account.service.AccountProfitManager;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class AccountScheduler {
-    private final AccountProfitUpdateExecutor accountProfitUpdateExecutor;
+    private final AccountProfitManager accountProfitManager;
 
     @Scheduled(cron = "0 0 0 * * ?")
     public void runAccountProfitUpdateJob() {
-        accountProfitUpdateExecutor.updateAccountProfitRate();
+        accountProfitManager.updateAccountProfitRate();
+    }
+
+    @Scheduled(cron = "0 0 1 * * ?")
+    public void runAccountProfitDeleteJob() {
+        accountProfitManager.deleteOldAccountProfits();
     }
 }

--- a/src/main/java/muzusi/application/account/service/AccountProfitManager.java
+++ b/src/main/java/muzusi/application/account/service/AccountProfitManager.java
@@ -8,6 +8,7 @@ import muzusi.domain.account.service.AccountService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,5 +42,14 @@ public class AccountProfitManager {
                 });
 
         accountProfitService.saveAll(accountProfits);
+    }
+
+    /**
+     * 14일이 지난 계좌 수익 데이터를 삭제하는 메서드
+     */
+    @Transactional
+    public void deleteOldAccountProfits() {
+        LocalDate dateTime = LocalDate.now().minusDays(14);
+        accountProfitService.deleteByDateTime(dateTime);
     }
 }

--- a/src/main/java/muzusi/application/account/service/AccountProfitManager.java
+++ b/src/main/java/muzusi/application/account/service/AccountProfitManager.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class AccountProfitUpdateExecutor {
+public class AccountProfitManager {
     private final AccountProfitService accountProfitService;
     private final UserHoldingService userHoldingService;
     private final AccountService accountService;

--- a/src/main/java/muzusi/domain/account/repository/AccountProfitRepository.java
+++ b/src/main/java/muzusi/domain/account/repository/AccountProfitRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface AccountProfitRepository extends JpaRepository<AccountProfit, Long> {
-    List<AccountProfit> findByAccount_idOrderByCreatedAtAsc(Long accountId, Pageable pageable);
+    List<AccountProfit> findByAccount_idOrderByCreatedAtDesc(Long accountId, Pageable pageable);
 }

--- a/src/main/java/muzusi/domain/account/repository/AccountProfitRepository.java
+++ b/src/main/java/muzusi/domain/account/repository/AccountProfitRepository.java
@@ -3,9 +3,17 @@ package muzusi.domain.account.repository;
 import muzusi.domain.account.entity.AccountProfit;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface AccountProfitRepository extends JpaRepository<AccountProfit, Long> {
     List<AccountProfit> findByAccount_idOrderByCreatedAtDesc(Long accountId, Pageable pageable);
+
+    @Modifying
+    @Query("DELETE FROM account_profit a WHERE a.createdAt < :dateTime")
+    void deleteByDateTimeBefore(@Param("dateTime") LocalDate dateTime);
 }

--- a/src/main/java/muzusi/domain/account/service/AccountProfitService.java
+++ b/src/main/java/muzusi/domain/account/service/AccountProfitService.java
@@ -18,6 +18,6 @@ public class AccountProfitService {
     }
 
     public List<AccountProfit> readByAccountId(Long accountId) {
-        return accountProfitRepository.findByAccount_idOrderByCreatedAtAsc(accountId, PageRequest.of(0, 14));
+        return accountProfitRepository.findByAccount_idOrderByCreatedAtDesc(accountId, PageRequest.of(0, 14));
     }
 }

--- a/src/main/java/muzusi/domain/account/service/AccountProfitService.java
+++ b/src/main/java/muzusi/domain/account/service/AccountProfitService.java
@@ -6,6 +6,7 @@ import muzusi.domain.account.repository.AccountProfitRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -19,5 +20,9 @@ public class AccountProfitService {
 
     public List<AccountProfit> readByAccountId(Long accountId) {
         return accountProfitRepository.findByAccount_idOrderByCreatedAtDesc(accountId, PageRequest.of(0, 14));
+    }
+
+    public void deleteByDateTime(LocalDate dateTime) {
+        accountProfitRepository.deleteByDateTimeBefore(dateTime);
     }
 }

--- a/src/main/java/muzusi/presentation/account/api/AccountApi.java
+++ b/src/main/java/muzusi/presentation/account/api/AccountApi.java
@@ -100,7 +100,17 @@ public interface AccountApi {
                                                 "createdAt": "2025-02-16T19:10:21.744044",
                                                 "totalRate0fReturn": -25.0,
                                                 "totalEvaluatedAmount": 1500000,
-                                                "totalProfitAmount": -500000
+                                                "totalProfitAmount": -500000,
+                                                "accountProfits": [
+                                                    {
+                                                        "totalBalance": 9500000,
+                                                        "createdAt": "2025-02-21"
+                                                    },
+                                                    {
+                                                        "totalBalance": 9300000,
+                                                        "createdAt": "2025-02-20"
+                                                    }
+                                                ]
                                             }
                                         }
                                     """)


### PR DESCRIPTION
## 배경
- 계좌 일일 수익률은 14일까지만 필요. 그 이후의 데이터 삭제가 필요.

## 작업 사항
- 삭제 로직 구현
- 계좌 swagger 작성

## 추가 논의
- 현재 작은 데이터라 단순히 호출하여 삭제하는 과정을 거치고 있습니다.
 news 부분에서도 이와 비슷한 로직이 있는데, 추후에 더 좋은 방법 (DB 파티셔닝 등)을 공부하여 적용시켜 보겠습니다.