### PR TITLE
Refact: 뉴스 삭제 로직 수정

### DIFF
--- a/src/main/java/muzusi/application/news/scheduler/NewsScheduler.java
+++ b/src/main/java/muzusi/application/news/scheduler/NewsScheduler.java
@@ -15,7 +15,7 @@ public class NewsScheduler {
         newsManagementService.createPostsFromNews();
     }
 
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 55 23 * * *")
     public void runNewsDeleteJob() {
         newsManagementService.deleteNews();
     }

--- a/src/main/java/muzusi/application/news/service/NewsManagementService.java
+++ b/src/main/java/muzusi/application/news/service/NewsManagementService.java
@@ -42,12 +42,11 @@ public class NewsManagementService {
 
     /**
      * 오래된 뉴스를 삭제하는 메서드.
-     * 2일이 지난 뉴스들을 삭제한다.
+     * 1일이 지난 뉴스들을 삭제한다.
      */
     @Transactional
     public void deleteNews() {
-        LocalDateTime twoDaysAgo = LocalDateTime.now().minusDays(2);
-        List<Long> newsIds = newsService.readIdsByDate(twoDaysAgo);
-        newsService.deleteByIds(newsIds);
+        LocalDateTime dateTime = LocalDateTime.now().minusDays(1);
+        newsService.deleteByDateTime(dateTime);
     }
 }

--- a/src/main/java/muzusi/domain/news/repository/NewsRepository.java
+++ b/src/main/java/muzusi/domain/news/repository/NewsRepository.java
@@ -9,16 +9,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public interface NewsRepository extends JpaRepository<News, Long> {
     Page<News> findByKeyword(String keyword, Pageable pageable);
     boolean existsByLink(String link);
 
-    @Query("SELECT n.id FROM news n WHERE n.pubDate < :dateTime")
-    List<Long> findIdsByPubDateBefore(@Param("dateTime") LocalDateTime dateTime);
-
     @Modifying
-    @Query("DELETE FROM news n WHERE n.id IN :ids")
-    void deleteByIds(@Param("ids") List<Long> ids);
+    @Query("DELETE FROM news n WHERE n.pubDate < :dateTime")
+    void deleteByDateTimeBefore(@Param("dateTime") LocalDateTime dateTime);
 }

--- a/src/main/java/muzusi/domain/news/service/NewsService.java
+++ b/src/main/java/muzusi/domain/news/service/NewsService.java
@@ -27,15 +27,11 @@ public class NewsService {
         return newsRepository.findByKeyword(keyword, pageable);
     }
 
-    public List<Long> readIdsByDate(LocalDateTime dateTime) {
-        return newsRepository.findIdsByPubDateBefore(dateTime);
-    }
-
     public boolean existsByLink(String link) {
         return newsRepository.existsByLink(link);
     }
 
-    public void deleteByIds(List<Long> ids) {
-        newsRepository.deleteByIds(ids);
+    public void deleteByDateTime(LocalDateTime dateTime) {
+        newsRepository.deleteByDateTimeBefore(dateTime);
     }
 }


### PR DESCRIPTION
## 배경
- 전의 로직에서는 날짜가 지난 데이터를 불러와 그 데이터들의 pk값을 이용하여 삭제하는 불필요한 과정이 있었음.
 시간을 기준으로 바로 삭제하는 로직 작성

## 작업 사항
- 뉴스 삭제 로직 수정
- 뉴스 삭제 기간 수정 (1일 <- 50개의 데이터만 보여주기에 1일 이상의 데이터가 필요없음)
- 뉴스 삭제 스케쥴러 수정 (자정에 삭제하면 전날의 뉴스가 다 사라짐. 뉴스를 받아오는 시간 전까지 데이터가 없을 수 있기에, 자정 5분 전으로 수정)

## 추가 논의
이번 pr과 같이 DB 파티셔닝에 대해 공부해보도록 하겠습니다.