### PR TITLE
Feature: StompJS disconnect 메서드 deprecated에 따른 코드 변경

### DIFF
--- a/src/main/java/muzusi/presentation/websocket/inteceptor/StompInterceptor.java
+++ b/src/main/java/muzusi/presentation/websocket/inteceptor/StompInterceptor.java
@@ -33,7 +33,7 @@ public class StompInterceptor implements ChannelInterceptor {
         if (StompCommand.SUBSCRIBE.equals(accessor.getCommand()))
             kisRealTimeTradeHandler.connect(stockCode);
 
-        if (StompCommand.DISCONNECT.equals(accessor.getCommand()) && stockCode != null)
+        if (StompCommand.UNSUBSCRIBE.equals(accessor.getCommand()))
             kisRealTimeTradeHandler.disconnect(stockCode);
 
         return message;


### PR DESCRIPTION
## 배경
- StompJS 7.0.0 이상 라이브러리 내 `disconnect` 삭제 및 `deactivate` 변경
- `deactivate` 내 header 포함 불가

## 작업 사항
- 구독 해제 확인 메서드 DISCONNECT → UNSUBSCRIBE 변경