### PR TITLE
Fix: 한국투자증권 웹소켓 연결 로직 수정

### DIFF
--- a/src/main/java/muzusi/infrastructure/kis/KisRealTimeTradeHandler.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisRealTimeTradeHandler.java
@@ -85,10 +85,16 @@ public class KisRealTimeTradeHandler extends KisWebSocketHandler {
      * @param stockCode : 주식 종목 코드
      */
     public void connect(String stockCode) {
-        if (subscribedStocks.size() >= MAX_CONNECTION)
-            throw new CustomException(StockErrorType.MAX_REQUEST_WEB_SOCKET);
-        subscribedStocks.compute(stockCode, (k, v) -> v == null ? 1 : v + 1);
-        request(stockCode, "1");
+        subscribedStocks.compute(stockCode, (k, v) -> {
+            if (v == null) {
+                if (subscribedStocks.size() >= MAX_CONNECTION)
+                    throw new CustomException(StockErrorType.MAX_REQUEST_WEB_SOCKET);
+                request(stockCode, "1");
+                return 1;
+            } else {
+                return v + 1;
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
## 배경
- 한국투자증권 웹소켓 연결 시 이미 구독된 종목에 대한 불필요 연결 확인

## 작업 사항
- 이미 구독된 종목의 경우 연결 미실행
- 이미 구독하고 있는 종목이 아닐 경우에만 에러 발생