### PR TITLE
Refact: JPQL 문구 QueryDsl 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ out/
 
 ### VS Code ###
 .vscode/
+
+src/main/generated
+
+### Mac OS ###
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,31 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
 	implementation 'io.github.daeyoung0726:api-link-checker:0.1.0'
+
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+def querydslDir = 'src/main/generated'
+
+sourceSets {
+	main.java.srcDirs += [querydslDir]
+}
+
+configurations {
+	querydsl.extendsFrom compileClasspath
+}
+
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+clean.doLast {
+	file(querydslDir).deleteDir()
 }

--- a/src/main/java/muzusi/domain/account/repository/AccountRepository.java
+++ b/src/main/java/muzusi/domain/account/repository/AccountRepository.java
@@ -2,32 +2,9 @@ package muzusi.domain.account.repository;
 
 import muzusi.domain.account.entity.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
-public interface AccountRepository extends JpaRepository<Account, Long> {
+public interface AccountRepository extends JpaRepository<Account, Long>, CustomAccountRepository {
     List<Account> findByUser_Id(Long userId);
-
-    @Query(value = "SELECT * FROM account a " +
-            "WHERE a.user_id = :userId " +
-            "ORDER BY a.created_at DESC LIMIT 1", nativeQuery = true)
-    Optional<Account> findLatestAccount(@Param("userId") Long userId);
-
-    @Query(value = "SELECT a.created_at FROM account a " +
-            "WHERE a.user_id = :userId " +
-            "ORDER BY a.created_at DESC LIMIT 1", nativeQuery = true)
-    LocalDateTime findLatestCreatedAt(@Param("userId") Long userId);
-
-    @Query(value = "SELECT * FROM account a " +
-            "WHERE a.id = ( " +
-            "    SELECT a2.id FROM account a2 " +
-            "    WHERE a2.user_id = a.user_id " +
-            "    ORDER BY a2.created_at DESC " +
-            "    LIMIT 1 " +
-            ")", nativeQuery = true)
-    List<Account> findLatestAccountsForAllUsers();
 }

--- a/src/main/java/muzusi/domain/account/repository/CustomAccountRepository.java
+++ b/src/main/java/muzusi/domain/account/repository/CustomAccountRepository.java
@@ -1,0 +1,13 @@
+package muzusi.domain.account.repository;
+
+import muzusi.domain.account.entity.Account;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface CustomAccountRepository {
+    Optional<Account> findLatestAccount(Long userId);
+    LocalDateTime findLatestCreatedAt(Long userId);
+    List<Account> findLatestAccountsForAllUsers();
+}

--- a/src/main/java/muzusi/domain/account/repository/CustomAccountRepositoryImpl.java
+++ b/src/main/java/muzusi/domain/account/repository/CustomAccountRepositoryImpl.java
@@ -1,0 +1,56 @@
+package muzusi.domain.account.repository;
+
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.account.entity.Account;
+import muzusi.domain.account.entity.QAccount;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class CustomAccountRepositoryImpl implements CustomAccountRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    private final QAccount account = QAccount.account;
+
+    @Override
+    public Optional<Account> findLatestAccount(Long userId) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .selectFrom(account)
+                        .where(account.user.id.eq(userId))
+                        .orderBy(account.createdAt.desc())
+                        .limit(1)
+                        .fetchOne()
+        );
+    }
+
+    @Override
+    public LocalDateTime findLatestCreatedAt(Long userId) {
+        return jpaQueryFactory
+                .select(account.createdAt)
+                .from(account)
+                .where(account.user.id.eq(userId))
+                .orderBy(account.createdAt.desc())
+                .limit(1)
+                .fetchOne();
+    }
+
+    @Override
+    public List<Account> findLatestAccountsForAllUsers() {
+        QAccount subAccount = new QAccount("subAccount");
+
+        return jpaQueryFactory
+                .selectFrom(account)
+                .where(account.createdAt.eq(
+                        JPAExpressions
+                                .select(subAccount.createdAt.max())
+                                .from(subAccount)
+                                .where(subAccount.user.id.eq(account.user.id))
+                ))
+                .fetch();
+    }
+}

--- a/src/main/java/muzusi/domain/holding/repository/CustomHoldingRepository.java
+++ b/src/main/java/muzusi/domain/holding/repository/CustomHoldingRepository.java
@@ -1,0 +1,13 @@
+package muzusi.domain.holding.repository;
+
+import muzusi.domain.holding.entity.Holding;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CustomHoldingRepository {
+    Optional<Holding> findLatestAccountHolding(Long userId, String stockCode);
+    boolean existsByLatestAccountHolding(Long userId, String stockCode);
+    void deleteByLatestAccountHolding(Long userId, String stockCode);
+    List<Holding> findLatestAccountAllHolding(Long userId);
+}

--- a/src/main/java/muzusi/domain/holding/repository/CustomHoldingRepositoryImpl.java
+++ b/src/main/java/muzusi/domain/holding/repository/CustomHoldingRepositoryImpl.java
@@ -1,0 +1,86 @@
+package muzusi.domain.holding.repository;
+
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.account.entity.QAccount;
+import muzusi.domain.holding.entity.Holding;
+import muzusi.domain.holding.entity.QHolding;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class CustomHoldingRepositoryImpl implements CustomHoldingRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    private final QHolding holding = QHolding.holding;
+    private final QAccount account = QAccount.account;
+
+    @Override
+    public Optional<Holding> findLatestAccountHolding(Long userId, String stockCode) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .selectFrom(holding)
+                        .innerJoin(account).on(holding.account.id.eq(account.id))
+                        .where(
+                                holding.account.id.eq(
+                                                JPAExpressions
+                                                        .select(account.id.max())
+                                                        .from(account)
+                                                        .where(account.user.id.eq(userId))
+                                        )
+                                        .and(holding.stockCode.eq(stockCode))
+                        )
+                        .where(holding.stockCode.eq(stockCode))
+                        .fetchOne()
+        );
+    }
+
+    public boolean existsByLatestAccountHolding(Long userId, String stockCode) {
+        return jpaQueryFactory
+                .selectOne()
+                .from(holding)
+                .innerJoin(account).on(holding.account.id.eq(account.id))
+                .where(
+                        holding.account.id.eq(
+                                        JPAExpressions
+                                                .select(account.id.max())
+                                                .from(account)
+                                                .where(account.user.id.eq(userId))
+                                )
+                                .and(holding.stockCode.eq(stockCode))
+                )
+                .fetchFirst() != null;
+    }
+
+    @Override
+    public void deleteByLatestAccountHolding(Long userId, String stockCode) {
+        jpaQueryFactory
+                .delete(holding)
+                .where(
+                        holding.account.id.in(
+                                JPAExpressions
+                                        .select(account.id.max())
+                                        .from(account)
+                                        .where(account.user.id.eq(userId))
+                        ),
+                        holding.stockCode.eq(stockCode)
+                )
+                .execute();
+    }
+
+    @Override
+    public List<Holding> findLatestAccountAllHolding(Long userId) {
+        return jpaQueryFactory
+                .selectFrom(holding)
+                .innerJoin(account).on(holding.account.id.eq(account.id))
+                .where(holding.account.id.eq(
+                        JPAExpressions
+                                .select(account.id.max())
+                                .from(account)
+                                .where(account.user.id.eq(userId))
+                ))
+                .fetch();
+    }
+}

--- a/src/main/java/muzusi/domain/holding/repository/HoldingRepository.java
+++ b/src/main/java/muzusi/domain/holding/repository/HoldingRepository.java
@@ -9,28 +9,6 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
-public interface HoldingRepository extends JpaRepository<Holding, Long> {
-    @Query(value = "SELECT * FROM holding " +
-            "WHERE account_id = (SELECT id FROM account WHERE user_id = :userId ORDER BY created_at DESC LIMIT 1) " +
-            "AND stock_code = :stockCode", nativeQuery = true)
-    Optional<Holding> findLatestAccountHolding(@Param("userId") Long userId, @Param("stockCode") String stockCode);
-
-    @Query(value = "SELECT EXISTS ( " +
-            "SELECT 1 FROM holding " +
-            "WHERE account_id = (SELECT id FROM account WHERE user_id = :userId ORDER BY created_at DESC LIMIT 1) " +
-            "AND stock_code = :stockCode )", nativeQuery = true)
-    Integer existsByLatestAccountHolding(@Param("userId") Long userId, @Param("stockCode") String stockCode);
-
-    @Modifying
-    @Query(value = "DELETE FROM holding " +
-            "WHERE account_id = (SELECT id FROM account WHERE user_id = :userId ORDER BY created_at DESC LIMIT 1 )" +
-            "AND stock_code = :stockCode", nativeQuery = true)
-    void deleteByLatestAccountHolding(@Param("userId") Long userId, @Param("stockCode") String stockCode);
-
-    @Query(value = "SELECT * FROM holding " +
-            "WHERE account_id = (SELECT id FROM account WHERE user_id = :userId ORDER BY created_at DESC LIMIT 1)",
-            nativeQuery = true)
-    List<Holding> findLatestAccountAllHolding(@Param("userId") Long userId);
-
+public interface HoldingRepository extends JpaRepository<Holding, Long>, CustomHoldingRepository {
     List<Holding> findByAccount_Id(Long accountId);
 }

--- a/src/main/java/muzusi/domain/holding/service/HoldingService.java
+++ b/src/main/java/muzusi/domain/holding/service/HoldingService.java
@@ -30,7 +30,7 @@ public class HoldingService {
     }
 
     public boolean existsByUserIdAndStockCode(Long userId, String stockCode) {
-        return holdingRepository.existsByLatestAccountHolding(userId, stockCode) == 1;
+        return holdingRepository.existsByLatestAccountHolding(userId, stockCode);
     }
 
     public void deleteByUserIdAndStockCode(Long userId, String stockCode) {

--- a/src/main/java/muzusi/infrastructure/config/QueryDslConfig.java
+++ b/src/main/java/muzusi/infrastructure/config/QueryDslConfig.java
@@ -1,0 +1,15 @@
+package muzusi.infrastructure.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 배경
- 가독성 + 컴파일 시점에서의 오류 문구를 찾기 위한 QueryDsl 적용

## 작업 사항
- QueryDsl 의존성 구현 및 gitignore을 통한 git 추척 제거
- Account, Holding 등의 복잡한 JPQL 문구 QueryDsl 적용

## 참고사항
1. **벌크 연산 중 영속성 컨텍스트 문제**
- 쿼리DSL을 통한 벌크 연산을 사용할 시, DB에 바로 접근을 하는 것이기에 영속성 컨텍스트의 값을 삭제시키지 않음.
- Holding 삭제 과정 중, 벌크 삭제로 인해 영속성 컨텍스트에서 바로 삭제 되지 않기에 같은 트랜잭션에서 조회 시, 그대로 조회 가능. (만약, 이것이 벌크 수정 연산이라면 업데이트 되기 전의 값을 조회한다는 뜻.)
- EntiyManager을 통해 직접 flush() 및 close()를 해줘야 함.
- 하지만, 해당 로직에서 account의 정보를 업데이트 하는 과정이 있기에 flush(), close()를 하게되면, account의 더티체킹을 하지 못하기에 적용하지는 않음

2. **QueryDsl 서브쿼리에서의 limit 연산 적용 불가능**
- QueryDsl 서브쿼리, JPQL은 limit가 적용되지 않는다고 함. 그래서, 최신 계좌는 id가 가장 큰 값이니, 그것을 이용하여 작성 (created를 기준으로하면 3중 쿼리가 되기에 id를 이용함) 
- 참고 블로그 [QueryDSL에서 SubQuery 에는 limit 를 사용 할 수 없다.](https://j-k4keye.tistory.com/75), [How to use limit() and offset() in subquery? - git  Issue](https://github.com/querydsl/querydsl/issues/3224)