### PR TITLE
Fix: 한국투자증권 웹소켓 세션 연결 종료 에러 수정

### DIFF
--- a/src/main/java/muzusi/application/websocket/scheduler/WebSocketConnectionScheduler.java
+++ b/src/main/java/muzusi/application/websocket/scheduler/WebSocketConnectionScheduler.java
@@ -2,7 +2,7 @@ package muzusi.application.websocket.scheduler;
 
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
-import muzusi.infrastructure.kis.KisWebSocketHandler;
+import muzusi.infrastructure.kis.KisRealTimeTradeHandler;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.scheduling.annotation.Schedules;
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class WebSocketConnectionScheduler {
     private final WebSocketConnectionManager connection;
-    private final KisWebSocketHandler kisRealTimeTradeHandler;
+    private final KisRealTimeTradeHandler kisRealTimeTradeHandler;
 
     @PostConstruct
     public void init() {
@@ -38,13 +38,16 @@ public class WebSocketConnectionScheduler {
 
     @Scheduled(cron = "0 30 15 * * 1-5")
     public void runDisconnectWebSocketToKis() {
+        kisRealTimeTradeHandler.getConnectingStockCodes()
+                .forEach(kisRealTimeTradeHandler::disconnect);
+
         if (connection.isConnected())
             connection.stop();
     }
 
     @Schedules({
             @Scheduled(cron = "0 * 9-14 * * 1-5"),
-            @Scheduled(cron = "0 0-30 15 * * 1-5")
+            @Scheduled(cron = "0 0-29 15 * * 1-5")
     })
     public void runKeepConnectionJob() {
         kisRealTimeTradeHandler.keepConnection();

--- a/src/main/java/muzusi/infrastructure/kis/KisRealTimeTradeHandler.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisRealTimeTradeHandler.java
@@ -13,6 +13,7 @@ import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -27,6 +28,10 @@ public class KisRealTimeTradeHandler extends KisWebSocketHandler {
     private static final String TR_ID = "H0STCNT0";
     private static final int MAX_CONNECTION = 41;
     private final ConcurrentHashMap<String, Integer> subscribedStocks = new ConcurrentHashMap<>(MAX_CONNECTION);
+
+    public List<String> getConnectingStockCodes() {
+        return subscribedStocks.keySet().stream().toList();
+    }
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) {

--- a/src/main/java/muzusi/infrastructure/kis/KisRealTimeTradeHandler.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisRealTimeTradeHandler.java
@@ -29,6 +29,11 @@ public class KisRealTimeTradeHandler extends KisWebSocketHandler {
     private static final int MAX_CONNECTION = 41;
     private final ConcurrentHashMap<String, Integer> subscribedStocks = new ConcurrentHashMap<>(MAX_CONNECTION);
 
+    /**
+     * 현재 구독 중인 주식 종목 코드 목록을 반환하는 메서드
+     * 
+     * @return : 현재 구독 주식 종목 코드 목록
+     */
     public List<String> getConnectingStockCodes() {
         return subscribedStocks.keySet().stream().toList();
     }

--- a/src/main/java/muzusi/infrastructure/kis/KisWebSocketHandler.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisWebSocketHandler.java
@@ -23,6 +23,11 @@ public abstract class KisWebSocketHandler extends TextWebSocketHandler {
      * - 연결 유지를 위한 PINGPONG 메시지 송신
      */
     public void keepConnection() {
+        if (session == null || !session.isOpen()) {
+            log.error("KIS session closed in keep connection");
+            return;
+        }
+
         Map<String, String> header = new HashMap<>();
         header.put("tr_id", "PINGPONG");
         header.put("datetime", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss")));


### PR DESCRIPTION
## 배경
- 한국투자증권 웹소켓 세션 종료 시각(15:30)에 에러 발생
   - 15:30에 동시에 세션 종료 + 하트비트 핑 송신으로 인한 에러 발생

## 작업 사항
- 하트비트 핑 송신 시간 수정 ~15:30 → ~15:29
- 세션 연결 종료 전 구독 종목 해제