### PR TITLE
Refact: 웹소켓 연결 관리 메서드 위치 변경

### DIFF
--- a/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
+++ b/src/main/java/muzusi/application/kis/scheduler/KisScheduler.java
@@ -24,7 +24,7 @@ public class KisScheduler {
         kisOAuthService.saveAccessToken();
     }
 
-    @Scheduled(cron = "0 0 0 1 1 ?")
+    @Scheduled(cron = "0 55 8 * * ?")
     public void runIssueWebSocketKeyJob() {
         kisOAuthService.saveWebSocketKey();
     }

--- a/src/main/java/muzusi/application/kis/service/KisOAuthService.java
+++ b/src/main/java/muzusi/application/kis/service/KisOAuthService.java
@@ -51,6 +51,7 @@ public class KisOAuthService {
                     .value(kisOAuthClient.getWebSocketKey())
                     .build();
 
+            kisAuthService.deleteWebSocketKey();
             kisAuthService.saveWebSocketKey(webSocketKey);
         }
     }

--- a/src/main/java/muzusi/application/kis/service/KisOAuthService.java
+++ b/src/main/java/muzusi/application/kis/service/KisOAuthService.java
@@ -4,22 +4,21 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import muzusi.application.kis.dto.KisAuthDto;
-import muzusi.infrastructure.redis.RedisService;
-import muzusi.infrastructure.redis.constant.KisConstant;
+import muzusi.infrastructure.kis.KisAuthService;
 import muzusi.infrastructure.kis.KisOAuthClient;
 import org.springframework.stereotype.Service;
-
-import java.time.Duration;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class KisOAuthService {
     private final KisOAuthClient kisOAuthClient;
-    private final RedisService redisService;
+    private final KisAuthService kisAuthService;
+
 
     @PostConstruct
-    public void issueWebSocketKey() {
+    public void saveKisAuthKey() {
+        this.saveAccessToken();
         this.saveWebSocketKey();
     }
 
@@ -35,7 +34,8 @@ public class KisOAuthService {
                     .value(response)
                     .build();
 
-            redisService.set(KisConstant.ACCESS_TOKEN_PREFIX.getValue(), accessToken, Duration.ofDays(1));
+            kisAuthService.deleteAccessToken();
+            kisAuthService.saveAccessToken(accessToken);
         }
     }
 
@@ -51,7 +51,7 @@ public class KisOAuthService {
                     .value(kisOAuthClient.getWebSocketKey())
                     .build();
 
-            redisService.set(KisConstant.WEBSOCKET_KEY_PREFIX.getValue(), webSocketKey, Duration.ofDays(365));
+            kisAuthService.saveWebSocketKey(webSocketKey);
         }
     }
 }

--- a/src/main/java/muzusi/infrastructure/kis/KisAuthService.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisAuthService.java
@@ -35,7 +35,11 @@ public class KisAuthService {
         redisService.set(KisConstant.ACCESS_TOKEN_PREFIX.getValue(), accessToken, Duration.ofDays(1));
     }
 
+    public void deleteWebSocketKey() {
+        redisService.del(KisConstant.WEBSOCKET_KEY_PREFIX.getValue());
+    }
+
     public void saveWebSocketKey(KisAuthDto.WebSocketKey webSocketKey) {
-        redisService.set(KisConstant.WEBSOCKET_KEY_PREFIX.getValue(), webSocketKey, Duration.ofDays(365));
+        redisService.set(KisConstant.WEBSOCKET_KEY_PREFIX.getValue(), webSocketKey, Duration.ofDays(1));
     }
 }

--- a/src/main/java/muzusi/infrastructure/kis/KisAuthService.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisAuthService.java
@@ -6,9 +6,11 @@ import muzusi.infrastructure.redis.RedisService;
 import muzusi.infrastructure.redis.constant.KisConstant;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
+
 @Component
 @RequiredArgsConstructor
-public class KisAuthProvider {
+public class KisAuthService {
     private final RedisService redisService;
     private KisAuthDto.AccessToken accessToken;
     private KisAuthDto.WebSocketKey webSocketKey;
@@ -23,5 +25,17 @@ public class KisAuthProvider {
         if (this.webSocketKey == null)
             this.webSocketKey = (KisAuthDto.WebSocketKey) redisService.get(KisConstant.WEBSOCKET_KEY_PREFIX.getValue());
         return this.webSocketKey;
+    }
+
+    public void deleteAccessToken() {
+        redisService.del(KisConstant.ACCESS_TOKEN_PREFIX.getValue());
+    }
+
+    public void saveAccessToken(KisAuthDto.AccessToken accessToken) {
+        redisService.set(KisConstant.ACCESS_TOKEN_PREFIX.getValue(), accessToken, Duration.ofDays(1));
+    }
+
+    public void saveWebSocketKey(KisAuthDto.WebSocketKey webSocketKey) {
+        redisService.set(KisConstant.WEBSOCKET_KEY_PREFIX.getValue(), webSocketKey, Duration.ofDays(365));
     }
 }

--- a/src/main/java/muzusi/infrastructure/kis/KisRealTimeTradeHandler.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisRealTimeTradeHandler.java
@@ -9,7 +9,6 @@ import muzusi.domain.stock.exception.StockErrorType;
 import muzusi.domain.trade.type.TradeType;
 import muzusi.global.exception.CustomException;
 import org.springframework.stereotype.Component;
-import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
@@ -37,17 +36,6 @@ public class KisRealTimeTradeHandler extends KisWebSocketHandler {
      */
     public List<String> getConnectingStockCodes() {
         return subscribedStocks.keySet().stream().toList();
-    }
-
-    @Override
-    public void afterConnectionEstablished(WebSocketSession session) {
-        this.session = session;
-    }
-
-    @Override
-    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
-        log.warn("KIS session closed");
-        super.afterConnectionClosed(session, status);
     }
 
     /**

--- a/src/main/java/muzusi/infrastructure/kis/KisRealTimeTradeHandler.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisRealTimeTradeHandler.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class KisRealTimeTradeHandler extends KisWebSocketHandler {
     private final TradeNotificationPublisher tradeNotificationPublisher;
     private final ObjectMapper objectMapper;
-    private final KisAuthProvider kisAuthProvider;
+    private final KisAuthService kisAuthService;
 
     private static final String TR_ID = "H0STCNT0";
     private static final int MAX_CONNECTION = 41;
@@ -139,7 +139,7 @@ public class KisRealTimeTradeHandler extends KisWebSocketHandler {
         }
 
         Map<String, String> header = new HashMap<>();
-        header.put("approval_key", kisAuthProvider.getWebSocketKey().getValue());
+        header.put("approval_key", kisAuthService.getWebSocketKey().getValue());
         header.put("custtype", "P");
         header.put("tr_type", trType);
         header.put("content-type", "utf-8");

--- a/src/main/java/muzusi/infrastructure/kis/KisRequestFactory.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisRequestFactory.java
@@ -9,14 +9,14 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class KisRequestFactory {
-    private final KisAuthProvider kisAuthProvider;
+    private final KisAuthService kisAuthService;
     private final KisProperties kisProperties;
 
     public HttpHeaders getHttpHeader(String trId) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
 
-        headers.add("authorization", kisAuthProvider.getAccessToken().getValue());
+        headers.add("authorization", kisAuthService.getAccessToken().getValue());
         headers.add("appkey", kisProperties.getAppKey());
         headers.add("appsecret", kisProperties.getAppSecret());
         headers.add("tr_id", trId);

--- a/src/main/java/muzusi/infrastructure/kis/KisWebSocketHandler.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisWebSocketHandler.java
@@ -2,6 +2,7 @@ package muzusi.infrastructure.kis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
@@ -16,6 +17,18 @@ import java.util.Map;
 public abstract class KisWebSocketHandler extends TextWebSocketHandler {
     protected static WebSocketSession session;
     protected final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        this.session = session;
+        super.afterConnectionEstablished(session);
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        log.warn("KIS session closed");
+        super.afterConnectionClosed(session, status);
+    }
 
     /**
      * 웹 소켓 연결 지속을 위한 메서드

--- a/src/main/java/muzusi/infrastructure/kis/KisWebSocketHandler.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisWebSocketHandler.java
@@ -21,6 +21,7 @@ public abstract class KisWebSocketHandler extends TextWebSocketHandler {
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         this.session = session;
+        log.warn("KIS session connected: {}", session.getId());
         super.afterConnectionEstablished(session);
     }
 


### PR DESCRIPTION
## 배경
- 클래스 책임에 따른 웹소켓 연결 관리 메서드 분리

## 작업 사항
- `afterConnectionEstabilished()`, `afterConnectionClosed()` 및 `WebSocketSession session` 위치 변경

## 추가 논의
- 조금 더 유연한 구조와 추가 계좌를 통한 세션 확대를 생각하면 웹소켓 관리 별도의 클래스 생성이 맞는 것 같습니다. 변경 시 연결 과정 등과 처리 방식에 대해 조금 더 고민할 필요가 있어 해당 부분의 차후 필요에 따라 수정하도록 하겠습니다.