### PR TITLE
Refact: 예약 내역 데이터 관리 RDB로 변경

### DIFF
--- a/src/main/java/muzusi/application/trade/dto/ReservationInfoDto.java
+++ b/src/main/java/muzusi/application/trade/dto/ReservationInfoDto.java
@@ -6,7 +6,7 @@ import muzusi.domain.trade.type.TradeType;
 import java.time.LocalDateTime;
 
 public record ReservationInfoDto(
-        String id,
+        Long id,
         Long userId,
         Long inputPrice,
         Integer stockCount,

--- a/src/main/java/muzusi/application/trade/service/StockTradeService.java
+++ b/src/main/java/muzusi/application/trade/service/StockTradeService.java
@@ -59,7 +59,7 @@ public class StockTradeService {
      * @param tradeReservationId : 예약주식 pk값
      */
     @Transactional
-    public void cancelTradeReservation(Long userId, String tradeReservationId) {
+    public void cancelTradeReservation(Long userId, Long tradeReservationId) {
         tradeReservationHandler.cancelTradeReservation(userId, tradeReservationId);
     }
 }

--- a/src/main/java/muzusi/application/trade/service/TradeReservationHandler.java
+++ b/src/main/java/muzusi/application/trade/service/TradeReservationHandler.java
@@ -97,7 +97,7 @@ public class TradeReservationHandler {
      * @param userId : 사용자 pk값
      * @param tradeReservationId : 예약주식 pk값
      */
-    public void cancelTradeReservation(Long userId, String tradeReservationId) {
+    public void cancelTradeReservation(Long userId, Long tradeReservationId) {
         TradeReservation reservation = tradeReservationService.readById(tradeReservationId)
                 .orElseThrow(() -> new CustomException(TradeErrorType.NOT_FOUND));
 
@@ -145,7 +145,7 @@ public class TradeReservationHandler {
      * @param tradeReservationId : 예약 내역 id
      * @param stockCode : 주식 종목 코드
      */
-    private void finalizeCancelReservation(String tradeReservationId, String stockCode) {
+    private void finalizeCancelReservation(Long tradeReservationId, String stockCode) {
         tradeReservationService.deleteById(tradeReservationId);
 
         if (!tradeReservationService.existsByStockCode(stockCode)) {

--- a/src/main/java/muzusi/application/trade/service/TradeReservationProcessor.java
+++ b/src/main/java/muzusi/application/trade/service/TradeReservationProcessor.java
@@ -96,7 +96,7 @@ public class TradeReservationProcessor {
      * @param stockCode : 종목 코드
      */
     private void processBuyOrders(Map<Long, List<TradeReservation>> totalBuyAmountMap, String stockCode) {
-        List<String> tradeReservationIds = new ArrayList<>();
+        List<Long> tradeReservationIds = new ArrayList<>();
         List<Trade> trades = new ArrayList<>();
 
         totalBuyAmountMap.forEach((userId, reservations) -> {
@@ -132,7 +132,7 @@ public class TradeReservationProcessor {
      * @param stockCode : 종목 코드
      */
     private void processSellOrders(Map<Long, List<TradeReservation>> totalSellStockMap, String stockCode) {
-        List<String> tradeReservationIds = new ArrayList<>();
+        List<Long> tradeReservationIds = new ArrayList<>();
         List<Trade> trades = new ArrayList<>();
 
         totalSellStockMap.forEach((userId, reservations) -> {
@@ -201,7 +201,7 @@ public class TradeReservationProcessor {
      * 2. 거래 내역 추가
      * 3. 종목 코드에 예약 내역 없으면, redis 값 삭제
      */
-    private void finalizeTrade(List<String> tradeReservationIds, List<Trade> trades, String stockCode) {
+    private void finalizeTrade(List<Long> tradeReservationIds, List<Trade> trades, String stockCode) {
         if (!tradeReservationIds.isEmpty()) {
             tradeReservationService.deleteAllByIds(tradeReservationIds);
         }

--- a/src/main/java/muzusi/domain/trade/entity/TradeReservation.java
+++ b/src/main/java/muzusi/domain/trade/entity/TradeReservation.java
@@ -1,35 +1,51 @@
 package muzusi.domain.trade.entity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import muzusi.domain.trade.type.TradeType;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Document(collection = "trade_reservation")
+@EntityListeners(AuditingEntityListener.class)
+@Entity(name = "trade_reservation")
 public class TradeReservation {
     @Id
-    private String id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
+    @Column(name = "user_id")
     private Long userId;
 
+    @Column(name = "input_price")
     private Long inputPrice;
 
+    @Column(name = "input_count")
     private Integer stockCount;
 
+    @Column(name = "stock_name")
     private String stockName;
 
+    @Column(name = "stock_code")
     private String stockCode;
 
+    @Enumerated(EnumType.STRING)
     private TradeType tradeType;
 
+    @Column(name = "created_at")
     @CreatedDate
     private LocalDateTime createdAt;
 

--- a/src/main/java/muzusi/domain/trade/repository/TradeReservationRepository.java
+++ b/src/main/java/muzusi/domain/trade/repository/TradeReservationRepository.java
@@ -1,15 +1,20 @@
 package muzusi.domain.trade.repository;
 
 import muzusi.domain.trade.entity.TradeReservation;
-import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface TradeReservationRepository extends MongoRepository<TradeReservation, String> {
+public interface TradeReservationRepository extends JpaRepository<TradeReservation, Long> {
     List<TradeReservation> findByStockCode(String stockCode);
     boolean existsByStockCode(String stockCode);
-
-    @Query(value = "{ 'userId': ?0 }", sort = "{ 'createdAt': -1 }")
     List<TradeReservation> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    @Modifying
+    @Query("DELETE FROM trade_reservation t WHERE t.id IN :ids")
+    void deleteAllByIds(@Param("ids") List<Long> ids);
+
 }

--- a/src/main/java/muzusi/domain/trade/service/TradeReservationService.java
+++ b/src/main/java/muzusi/domain/trade/service/TradeReservationService.java
@@ -21,7 +21,7 @@ public class TradeReservationService {
         return tradeReservationRepository.findAll();
     }
 
-    public Optional<TradeReservation> readById(String id) {
+    public Optional<TradeReservation> readById(Long id) {
         return tradeReservationRepository.findById(id);
     }
 
@@ -37,12 +37,12 @@ public class TradeReservationService {
         return tradeReservationRepository.existsByStockCode(stockCode);
     }
 
-    public void deleteById(String id) {
+    public void deleteById(Long id) {
         tradeReservationRepository.deleteById(id);
     }
 
-    public void deleteAllByIds(List<String> ids) {
-        tradeReservationRepository.deleteAllById(ids);
+    public void deleteAllByIds(List<Long> ids) {
+        tradeReservationRepository.deleteAllByIds(ids);
     }
 
     public void deleteAll() {

--- a/src/main/java/muzusi/presentation/trade/api/TradeApi.java
+++ b/src/main/java/muzusi/presentation/trade/api/TradeApi.java
@@ -127,5 +127,5 @@ public interface TradeApi {
                     }))
     })
     ResponseEntity<?> cancelTradeReservation(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                             @PathVariable String tradeReservationId);
+                                             @PathVariable Long tradeReservationId);
 }

--- a/src/main/java/muzusi/presentation/trade/controller/TradeController.java
+++ b/src/main/java/muzusi/presentation/trade/controller/TradeController.java
@@ -34,7 +34,7 @@ public class TradeController implements TradeApi {
     @Override
     @DeleteMapping("/{tradeReservationId}")
     public ResponseEntity<?> cancelTradeReservation(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                    @PathVariable String tradeReservationId) {
+                                                    @PathVariable Long tradeReservationId) {
         stockTradeService.cancelTradeReservation(userDetails.getUserId(), tradeReservationId);
 
         return ResponseEntity.ok(SuccessResponse.ok());

--- a/src/test/java/muzusi/application/trade/service/TradeReservationHandlerTest.java
+++ b/src/test/java/muzusi/application/trade/service/TradeReservationHandlerTest.java
@@ -158,7 +158,7 @@ class TradeReservationHandlerTest {
     @DisplayName("예약 매수 취소 테스트")
     void cancelReservationPurchaseTest() {
         // given
-        String tradeReservationId = "tradeReservationId";
+        Long tradeReservationId = 1L;
         given(tradeReservationService.readById(tradeReservationId)).willReturn(Optional.ofNullable(buyTradeReservation));
         given(accountService.readByUserId(1L)).willReturn(Optional.ofNullable(account));
         Long currentAccountBalance = account.getBalance();
@@ -178,7 +178,7 @@ class TradeReservationHandlerTest {
     @DisplayName("예약 매도 취소 테스트")
     void cancelReservationSaleTest() {
         // given
-        String tradeReservationId = "tradeReservationId";
+        Long tradeReservationId = 1L;
         given(tradeReservationService.readById(tradeReservationId)).willReturn(Optional.ofNullable(sellTradeReservation));
         given(holdingService.readByUserIdAndStockCode(1L, "000610")).willReturn(Optional.ofNullable(holding));
         int currentReservedStockCount = holding.getReservedStockCount();
@@ -195,7 +195,7 @@ class TradeReservationHandlerTest {
     @DisplayName("예약 취소에 대한 권한 없음")
     void cancelReservationFailedByForbidden() {
         // given
-        String tradeReservationId = "tradeReservationId";
+        Long tradeReservationId = 1L;
         given(tradeReservationService.readById(tradeReservationId)).willReturn(Optional.ofNullable(sellTradeReservation));
         Long anotherUserId = 2L;
 


### PR DESCRIPTION
## 배경
- 얘약 내역은 정형화된 데이터임. 또한, 일관성이 중요함. nosql보다는 rdb가 적절하다고 판단.

## 작업 사항
- rdb 변경

## 추가 논의
x