### PR TITLE
Refact: default branch 변경으로 인한 CI/CD 브랜치명 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: Continuous Deployment
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "main" ]
   workflow_dispatch:
     inputs:
       logLevel:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: [ "develop" ]
+    branches: [ "main" ]
   workflow_dispatch:
     inputs:
       logLevel:


### PR DESCRIPTION
## 배경
default branch 변경으로 인한 CI/CD 브랜치명 변경

## 작업 사항
- 브렌치명 변경

## 추가 논의
x