### PR TITLE
Refact: 주식 분봉 차트 및 현재가 캐싱 클래스 분리

### DIFF
--- a/src/main/java/muzusi/domain/stock/repository/StockMinutesCacheRepository.java
+++ b/src/main/java/muzusi/domain/stock/repository/StockMinutesCacheRepository.java
@@ -1,0 +1,33 @@
+package muzusi.domain.stock.repository;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.stock.dto.StockChartInfoDto;
+import muzusi.infrastructure.redis.RedisService;
+import muzusi.infrastructure.redis.constant.KisConstant;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class StockMinutesCacheRepository {
+    private final RedisService redisService;
+    private final static String KEY_PREFIX = KisConstant.MINUTES_CHART_PREFIX.getValue();
+
+    public void saveAll(Collection<StockChartInfoDto> stockChartInfoList) {
+        stockChartInfoList.forEach(stockChartInfo -> {
+            redisService.setList(KEY_PREFIX + ":" + stockChartInfo.stockCode(), stockChartInfo);
+        });
+    }
+
+    public List<StockChartInfoDto> findAll(String stockCode) {
+        return redisService.getList(KEY_PREFIX + ":" + stockCode).stream()
+                .map(stockCharInfo -> (StockChartInfoDto) stockCharInfo)
+                .toList();
+    }
+
+    public void delete(String stockCode) {
+        redisService.del(KEY_PREFIX + ":" + stockCode);
+    }
+}

--- a/src/main/java/muzusi/domain/stock/repository/StockPriceCacheRepository.java
+++ b/src/main/java/muzusi/domain/stock/repository/StockPriceCacheRepository.java
@@ -1,0 +1,19 @@
+package muzusi.domain.stock.repository;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.infrastructure.redis.RedisService;
+import muzusi.infrastructure.redis.constant.KisConstant;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class StockPriceCacheRepository {
+    private final RedisService redisService;
+    private final static String KEY = KisConstant.INQUIRE_PRICE_PREFIX.getValue();
+    
+    public void saveAll(Map<String, Object> stockPriceMap) {
+        redisService.addToHash(KEY, stockPriceMap);
+    }
+}

--- a/src/main/java/muzusi/domain/stock/service/StockMinutesService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockMinutesService.java
@@ -1,17 +1,21 @@
 package muzusi.domain.stock.service;
 
 import lombok.RequiredArgsConstructor;
+import muzusi.application.stock.dto.StockChartInfoDto;
 import muzusi.domain.stock.entity.StockMinutes;
+import muzusi.domain.stock.repository.StockMinutesCacheRepository;
 import muzusi.domain.stock.repository.StockMinutesRepository;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class StockMinutesService {
     private final StockMinutesRepository stockMinutesRepository;
+    private final StockMinutesCacheRepository stockMinutesCacheRepository;
 
     public void save(StockMinutes stockMinutes) {
         stockMinutesRepository.save(stockMinutes);
@@ -27,5 +31,17 @@ public class StockMinutesService {
 
     public void deleteByDateBefore(LocalDate date) {
         stockMinutesRepository.deleteByDateBefore(date);
+    }
+
+    public void saveAllInCache(Collection<StockChartInfoDto> stockChartInfoList) {
+        stockMinutesCacheRepository.saveAll(stockChartInfoList);
+    }
+
+    public List<StockChartInfoDto> readAllInCache(String stockCode) {
+        return stockMinutesCacheRepository.findAll(stockCode);
+    }
+
+    public void deleteInCache(String stockCode) {
+        stockMinutesCacheRepository.delete(stockCode);
     }
 }

--- a/src/main/java/muzusi/domain/stock/service/StockPriceService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockPriceService.java
@@ -1,0 +1,17 @@
+package muzusi.domain.stock.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.stock.repository.StockPriceCacheRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class StockPriceService {
+    private final StockPriceCacheRepository stockPriceCacheRepository;
+
+    public void saveAll(Map<String, Object> stockPriceMap) {
+        stockPriceCacheRepository.saveAll(stockPriceMap);
+    }
+}


### PR DESCRIPTION
## 배경
- #107 작업 전 `KisStockMinutesService` 클래스 내 책임 분리 필요
: `KisStockMinutesService` 내에서 `RedisService`를 직접 호출 X → 주식 분봉 데이터 & 주식 현재가 저장 용 클래스 분리

## 작업 사항
- `StockMinutesCacheRepository` 추가 및 `StockMinutesService` 내 주식 분봉 데이터 캐싱 관련 메서드 추가
- `StockPriceCacheRepository` 및 `StockPriceService` 추가

## 추가 논의
- 현재 존재하는 주식 현재가 조회 로직들(`TradeReservationTrigger.triggerTradeReservations()`)에도 차후 `StockPriceService`를 적용해야할 것 같습니다.
현재는 PR에 대한 승인이 이루어지지 않아 기타 다른 코드들은 수정하지 않았습니다!