### PR TITLE
Feature: 주식 차트 생성 및 스케줄링 적용

### DIFF
--- a/src/main/java/muzusi/application/stock/scheduler/StockScheduler.java
+++ b/src/main/java/muzusi/application/stock/scheduler/StockScheduler.java
@@ -1,0 +1,17 @@
+package muzusi.application.stock.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.stock.service.StockChartService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StockScheduler {
+    private final StockChartService stockChartService;
+
+    @Scheduled(cron = "0 0 9 * * 1-5")
+    public void runCreateStockChartJob() {
+        stockChartService.createStockChart();
+    }
+}

--- a/src/main/java/muzusi/application/stock/service/StockChartService.java
+++ b/src/main/java/muzusi/application/stock/service/StockChartService.java
@@ -1,0 +1,113 @@
+package muzusi.application.stock.service;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.domain.stock.entity.StockDaily;
+import muzusi.domain.stock.entity.StockMonthly;
+import muzusi.domain.stock.entity.StockWeekly;
+import muzusi.domain.stock.entity.StockYearly;
+import muzusi.domain.stock.service.StockDailyService;
+import muzusi.domain.stock.service.StockMonthlyService;
+import muzusi.domain.stock.service.StockWeeklyService;
+import muzusi.domain.stock.service.StockYearlyService;
+import muzusi.infrastructure.data.StockCodeProvider;
+import muzusi.infrastructure.kis.KisStockClient;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Component
+@RequiredArgsConstructor
+public class StockChartService {
+    private final StockDailyService stockDailyService;
+    private final StockWeeklyService stockWeeklyService;
+    private final StockMonthlyService stockMonthlyService;
+    private final StockYearlyService stockYearlyService;
+    private final StockCodeProvider stockCodeProvider;
+    private final KisStockClient kisStockClient;
+
+    public void createStockChart() {
+        LocalDateTime now = LocalDateTime.now();
+        List<String> stockCodeList = stockCodeProvider.getAllStockCodes();
+
+        Map<String, Long> stockPriceMap = IntStream.range(0, stockCodeList.size())
+                .mapToObj(idx -> {
+                    if (idx % 15 == 0) {
+                        try {
+                            Thread.sleep(1500L);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+
+                    return Map.entry(stockCodeList.get(idx), kisStockClient.getStockInquirePrice(stockCodeList.get(idx)));
+                })
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        List<StockDaily> stockDailies = stockPriceMap.entrySet().stream()
+                .map(stockPriceInfo -> StockDaily.builder()
+                        .stockCode(stockPriceInfo.getKey())
+                        .date(now)
+                        .open(stockPriceInfo.getValue())
+                        .build()).toList();
+
+        stockDailyService.saveAll(stockDailies);
+
+        if (now.getDayOfWeek() == DayOfWeek.MONDAY) {
+            List<StockWeekly> stockWeeklies = stockPriceMap .entrySet().stream()
+                    .map(stockPriceInfo -> StockWeekly.builder()
+                            .stockCode(stockPriceInfo.getKey())
+                            .date(now)
+                            .open(stockPriceInfo.getValue())
+                            .build()).toList();
+
+            stockWeeklyService.saveAll(stockWeeklies);
+        }
+
+        if (now.equals(getFirstDayOfMonth(now))) {
+            List<StockMonthly> stockMonthlies = stockPriceMap.entrySet().stream()
+                    .map(stockPriceInfo -> StockMonthly.builder()
+                            .stockCode(stockPriceInfo.getKey())
+                            .date(now)
+                            .open(stockPriceInfo.getValue())
+                            .build()).toList();
+
+            stockMonthlyService.saveAll(stockMonthlies);
+        }
+
+        if (now.equals(getFirstDayOfYear(now))) {
+            List<StockYearly> stockYearlies = stockPriceMap.entrySet().stream()
+                    .map(stockPriceInfo -> StockYearly.builder()
+                            .stockCode(stockPriceInfo.getKey())
+                            .date(now)
+                            .open(stockPriceInfo.getValue())
+                            .build()).toList();
+
+            stockYearlyService.saveAll(stockYearlies);
+        }
+    }
+
+    private LocalDateTime getFirstDayOfMonth(LocalDateTime date) {
+        LocalDateTime day = LocalDateTime.of(date.getYear(), date.getMonth(), 1, 9, 0);
+
+        while (day.getDayOfWeek() == DayOfWeek.SATURDAY || day.getDayOfWeek() == DayOfWeek.SUNDAY) {
+            day = day.plusDays(1);
+        }
+
+        return day;
+    }
+
+    private LocalDateTime getFirstDayOfYear(LocalDateTime date) {
+        LocalDateTime day = LocalDateTime.of(date.getYear(), 1, 1, 9, 0);
+
+        while (day.getDayOfWeek() == DayOfWeek.SATURDAY || day.getDayOfWeek() == DayOfWeek.SUNDAY) {
+            day = day.plusDays(1);
+        }
+
+        return day;
+    }
+}

--- a/src/main/java/muzusi/domain/stock/service/StockDailyService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockDailyService.java
@@ -16,6 +16,10 @@ public class StockDailyService {
         stockDailyRepository.save(stockDaily);
     }
 
+    public void saveAll(List<StockDaily> stockDailies) {
+        stockDailyRepository.saveAll(stockDailies);
+    }
+
     public List<StockDaily> readByStockCode(String stockCode) {
         return stockDailyRepository.findByStockCodeOrderByDateAsc(stockCode);
     }

--- a/src/main/java/muzusi/domain/stock/service/StockMonthlyService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockMonthlyService.java
@@ -19,4 +19,8 @@ public class StockMonthlyService {
     public List<StockMonthly> readByStockCode(String stockCode) {
         return stockMonthlyRepository.findByStockCodeOrderByDateAsc(stockCode);
     }
+
+    public void saveAll(List<StockMonthly> stockMonthlies) {
+        stockMonthlyRepository.saveAll(stockMonthlies);
+    }
 }

--- a/src/main/java/muzusi/domain/stock/service/StockWeeklyService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockWeeklyService.java
@@ -16,6 +16,10 @@ public class StockWeeklyService {
         stockWeeklyRepository.save(stockWeekly);
     }
 
+    public void saveAll(List<StockWeekly> stockWeeklies) {
+        stockWeeklyRepository.saveAll(stockWeeklies);
+    }
+
     public List<StockWeekly> readByStockCode(String stockCode) {
         return stockWeeklyRepository.findByStockCodeOrderByDateAsc(stockCode);
     }

--- a/src/main/java/muzusi/domain/stock/service/StockYearlyService.java
+++ b/src/main/java/muzusi/domain/stock/service/StockYearlyService.java
@@ -19,4 +19,8 @@ public class StockYearlyService {
     public List<StockYearly> readByStockCode(String stockCode) {
         return stockYearlyRepository.findByStockCodeOrderByDateAsc(stockCode);
     }
+
+    public void saveAll(List<StockYearly> stockYearlies) {
+        stockYearlyRepository.saveAll(stockYearlies);
+    }
 }


### PR DESCRIPTION
## 배경
- #107 을 위한 주식 차트 도큐먼트 생성 필요

## 작업 사항
- 평일 9시에 주식 차트 도큐먼트 생성
   - StockDaily: 매일 9시 생성
   - StockWeekly: 매주 월요일 생성
   - StockMonthly: 매월 첫째 주 월요일 생성
   - StockYearly: 매년 첫월 첫째 주 월요일 생성 

<img width="600" alt="image" src="https://github.com/user-attachments/assets/95da8151-766a-4c7e-ad0f-8419c0b6738e" />


## 추가 논의
- PR 크기를 고려하여 부득이하게 매일 9시 주식 차트 도큐먼트 생성 작업만 분리하여 PR을 작성하였습니다. 따라서, 해당 PR이 승인 후 다음 PR(장 종료 후 주식 차트 데이터 저장)과 동시에 main 브랜치에 병합하도록 하겠습니다.