### PR TITLE
Refact: 주식 차트 조회 서비스 로직 리팩토링

### DIFF
--- a/src/main/java/muzusi/application/stock/service/StockChartQueryService.java
+++ b/src/main/java/muzusi/application/stock/service/StockChartQueryService.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-public class StockHistoryService {
+public class StockChartQueryService {
     private final StockMinutesService stockMinutesService;
     private final StockDailyService stockDailyService;
     private final StockWeeklyService stockWeeklyService;

--- a/src/main/java/muzusi/presentation/stock/controller/StockHistoryController.java
+++ b/src/main/java/muzusi/presentation/stock/controller/StockHistoryController.java
@@ -1,7 +1,7 @@
 package muzusi.presentation.stock.controller;
 
 import lombok.RequiredArgsConstructor;
-import muzusi.application.stock.service.StockHistoryService;
+import muzusi.application.stock.service.StockChartQueryService;
 import muzusi.domain.stock.type.StockPeriodType;
 import muzusi.global.response.success.SuccessResponse;
 import muzusi.presentation.stock.api.StockHistoryApi;
@@ -16,14 +16,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/stocks")
 @RequiredArgsConstructor
 public class StockHistoryController implements StockHistoryApi {
-    private final StockHistoryService stockHistoryService;
+    private final StockChartQueryService stockChartQueryService;
 
     @Override
     @GetMapping("/{stockCode}")
     public ResponseEntity<?> getStockHistory(@PathVariable String stockCode,
                                              @RequestParam StockPeriodType period) {
         return ResponseEntity.ok(
-                SuccessResponse.from(stockHistoryService.getStockHistoryByType(stockCode, period))
+                SuccessResponse.from(stockChartQueryService.getStockHistoryByType(stockCode, period))
         );
     }
 }

--- a/src/test/java/muzusi/application/stock/service/StockChartQueryServiceTest.java
+++ b/src/test/java/muzusi/application/stock/service/StockChartQueryServiceTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 @ExtendWith(MockitoExtension.class)
-public class StockHistoryServiceTest {
+public class StockChartQueryServiceTest {
     
     @Mock
     private StockMinutesService stockMinutesService;
@@ -46,7 +46,7 @@ public class StockHistoryServiceTest {
     private StockYearlyService stockYearlyService;
     
     @InjectMocks
-    private StockHistoryService stockHistoryService;
+    private StockChartQueryService stockChartQueryService;
     
     private final String stockCode = "000001";
     
@@ -76,7 +76,7 @@ public class StockHistoryServiceTest {
             mockedLocalDateTime.when(LocalDateTime::now).thenReturn(mockNow);
             
             // when
-            List<StockChartInfoDto> result = stockHistoryService
+            List<StockChartInfoDto> result = stockChartQueryService
                     .getStockHistoryByType(stockCode, StockPeriodType.MINUTES_TODAY);
             
             // then
@@ -98,7 +98,7 @@ public class StockHistoryServiceTest {
             
             // when
             CustomException exception = assertThrows(CustomException.class, ()
-                    -> stockHistoryService.getStockHistoryByType(stockCode, StockPeriodType.MINUTES_TODAY));
+                    -> stockChartQueryService.getStockHistoryByType(stockCode, StockPeriodType.MINUTES_TODAY));
             
             // then
             assertEquals(exception.getErrorType(), StockErrorType.NOT_AVAILABLE_MINUTES_CHART);
@@ -119,7 +119,7 @@ public class StockHistoryServiceTest {
             
             // when
             CustomException exception = assertThrows(CustomException.class, ()
-                    -> stockHistoryService.getStockHistoryByType(stockCode, StockPeriodType.MINUTES_TODAY));
+                    -> stockChartQueryService.getStockHistoryByType(stockCode, StockPeriodType.MINUTES_TODAY));
             
             // then
             assertEquals(exception.getErrorType(), StockErrorType.NOT_AVAILABLE_MINUTES_CHART);


### PR DESCRIPTION
## 배경
- 당일 분봉 차트 조회 로직 내 `RedisService` 의존성 직접 사용으로 인한 클래스간 결합도 증가 
- 당일 분봉 차트 조회 시 메서드 내에서 장 시작/종료 시간 객체 생성으로 인한 비용 발생
- 주식 차트 조회 서비스 이름 혼동으로 인한 명확한 이름 변경 필요

## 작업 사항
- 당일 분봉 차트 조회 로직 내 `ReidsService` 의존성 제거
- 장 시작/종료 시간 객체 위치 및 타입 변경: 당일 분봉 차트 조회 메서드 내 → 클래스 final 멤버
- 주식 차트 조회 서비스 이름 변경: `StockHistoryService` → `StockChartQueryService`
