### PR TITLE
Feature: 한국투자증권 주식 분봉 데이터 API 호출 기능 쓰로틀링 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	implementation("com.google.guava:guava:33.4.8-jre")
 }
 
 tasks.named('test') {

--- a/src/main/java/muzusi/infrastructure/kis/KisRequestFactory.java
+++ b/src/main/java/muzusi/infrastructure/kis/KisRequestFactory.java
@@ -25,4 +25,17 @@ public class KisRequestFactory {
 
         return headers;
     }
+    
+    public HttpHeaders getHttpHeader(String trId, String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        
+        headers.add("authorization", accessToken);
+        headers.add("appkey", kisProperties.getAppKey());
+        headers.add("appsecret", kisProperties.getAppSecret());
+        headers.add("tr_id", trId);
+        headers.add("custtype", "P");
+        
+        return headers;
+    }
 }

--- a/src/main/java/muzusi/infrastructure/kis/stock/KisStockClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/stock/KisStockClient.java
@@ -29,8 +29,8 @@ public class KisStockClient {
     private static final String MINUTES_CHART_TR_ID = "FHKST03010200";
     private static final String INQUIRE_PRICE_TR_ID = "FHKST01010100";
 
-    public StockChartInfoDto getStockMinutesChartInfo(String code, LocalDateTime time) {
-        HttpHeaders headers = kisRequestFactory.getHttpHeader(MINUTES_CHART_TR_ID);
+    public StockChartInfoDto getStockMinutesChartInfo(String code, LocalDateTime time, String accessToken) {
+        HttpHeaders headers = kisRequestFactory.getHttpHeader(MINUTES_CHART_TR_ID, accessToken);
 
         String uri = UriComponentsBuilder.fromUriString(kisProperties.getUrl(KisUrlConstant.TIME_ITEM_CHART_PRICE))
                 .queryParam("FID_ETC_CLS_CODE", "")

--- a/src/main/java/muzusi/infrastructure/kis/util/KisErrorParser.java
+++ b/src/main/java/muzusi/infrastructure/kis/util/KisErrorParser.java
@@ -1,0 +1,63 @@
+package muzusi.infrastructure.kis.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KisErrorParser {
+    private final ObjectMapper objectMapper;
+    
+    private static final String ERROR_MSG_KEY = "msg_cd";
+    private static final String API_REQUEST_EXCEEDED_ERROR_CODE = "EGW00201";
+    
+    /**
+     * 한국투자증권 응답 에러 메시지에서 API 호출 유량 초과 인지를 확인하는 메서드
+     *
+     * @param errorMessage  한국투자증권 응답 에러 메시지
+     * @return              API 호출 유량 초과에 따른 에러 발생 여부
+     */
+    public boolean isApiRequestExceeded(String errorMessage) {
+        try {
+            int startIndex = errorMessage.indexOf('{');
+            
+            if (startIndex == -1) {
+                return false;
+            }
+            
+            String errorCode = this.parseErrorCode(errorMessage, startIndex);
+            
+            if (errorCode == null) {
+                return false;
+            }
+            
+            if (API_REQUEST_EXCEEDED_ERROR_CODE.equals(errorCode)) {
+                return true;
+            }
+            
+            return false;
+        } catch (JsonProcessingException e) {
+            log.error("[JSON PARSING ERROR] Failed to parse a KIS error message");
+            return false;
+        }
+    }
+    
+    /**
+     * 한국투자증권 응답 에러 메시지의 Json 파트 부분에서 에러 응답 코드를 파싱하는 메서드
+     *
+     * @param errorMessage  한국투자증권 응답 에러 메시지
+     * @param startIndex    Json 파트 부분 시작 인덱스
+     * @return              에러 응답 코드
+     */
+    private String parseErrorCode(String errorMessage, int startIndex) throws JsonProcessingException {
+        JsonNode errorNode = objectMapper.readTree(errorMessage.substring(startIndex));
+        JsonNode errorCode = errorNode.get(ERROR_MSG_KEY);
+        
+        return errorCode == null ? null : errorCode.asText();
+    }
+}


### PR DESCRIPTION
## 배경
- 한국투자증권 주식 분봉 데이터 API 호출 시, 15번의 호출마다 1초씩 Thread Sleep을 진행하여 idle한 시간 발생
	- 주식 종목 코드: 2,742개
	- Thread Sleep: 1초 / 15회 (1sec per 15times)
	- idle한 횟수: 2,742 / 15 = 182.8 ⇒ 181회
	- idle한 시간: 181 * 1초 = 181초 ⇒ 약 3분
	- 현재 API 호출 및 저장에 걸리는 총 시간(total time): 432초 (7분 12초)

	⇒ 쓰로틀링(Rate Limit)을 사용하여 한국투자증권 호출 유량(1초당 최대 20번) 제한 정책에 대응하도록 초당 요청을 보내는 횟수를 조절

- 한국투자증권 주식 분봉 데이터 API 호출  실패 시, 재시도 로직 추가 필요
- 그 외 주식 분봉 데이터 호출 시 성능 개선사항 식별


## 작업 사항
- google guava 디펜던시 적용 | (25df005d8796c385caa1bbdcae2edb3d4a6cddcd)

- 한국투자

## 추가 논의

<!-- 발생한 이슈 -->