### PR TITLE
Feature: 한국투자증권 API 호출 로직 내 RateLimiter 전역 적용

### DIFF
--- a/src/main/java/muzusi/application/kis/service/KisStockChartUpdater.java
+++ b/src/main/java/muzusi/application/kis/service/KisStockChartUpdater.java
@@ -33,7 +33,7 @@ public class KisStockChartUpdater {
     private final StockPriceService stockPriceService;
     private final KisAuthService kisAuthService;
     
-    private final RateLimiter rateLimiter = RateLimiter.create(15);
+    private final RateLimiter kisRateLimiter;
     private static final int BATCH_SIZE = 500;
 
     /**
@@ -54,7 +54,7 @@ public class KisStockChartUpdater {
 
         for (String code : stockCodeProvider.getAllStockCodes()) {
             try {
-                rateLimiter.acquire();
+                kisRateLimiter.acquire();
                 StockChartInfoDto stockChartInfo = kisStockClient.getStockMinutesChartInfo(code, now, accessToken);
                 stockChartInfoMap.put(code, stockChartInfo);
     

--- a/src/main/java/muzusi/application/kis/service/KisStockRankingUpdater.java
+++ b/src/main/java/muzusi/application/kis/service/KisStockRankingUpdater.java
@@ -1,5 +1,6 @@
 package muzusi.application.kis.service;
 
+import com.google.common.util.concurrent.RateLimiter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import muzusi.application.kis.dto.KisDto;
@@ -17,6 +18,7 @@ import java.util.List;
 public class KisStockRankingUpdater {
     private final KisRankingClient kisRankingClient;
     private final StockRankingService stockRankingService;
+    private final RateLimiter kisRateLimiter;
     
     /**
      * 거래량 기준 주식 순위를 저장하는 메서드
@@ -24,6 +26,8 @@ public class KisStockRankingUpdater {
      * - 주식 순위는 Redis 내 저장
      */
     public void saveVolumeRank() {
+        kisRateLimiter.acquire();
+        
         List<StockRankDto> stockRanking = kisRankingClient.getVolumeRank();
 
         stockRankingService.deleteVolumeRankingCache();
@@ -39,6 +43,8 @@ public class KisStockRankingUpdater {
      * - 주식 순위는 Redis 내 저장
      */
     public void saveFallingAndRisingRank() {
+        kisRateLimiter.acquire();
+        
         List<StockRankDto> risingStockRanking = kisRankingClient.getRisingFluctuationRank();
         List<StockRankDto> fallingStockRanking = kisRankingClient.getFallingFluctuationRank();
 

--- a/src/main/java/muzusi/infrastructure/config/GuavaConfig.java
+++ b/src/main/java/muzusi/infrastructure/config/GuavaConfig.java
@@ -1,0 +1,14 @@
+package muzusi.infrastructure.config;
+
+import com.google.common.util.concurrent.RateLimiter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GuavaConfig {
+
+    @Bean
+    public RateLimiter kisRateLimiter() {
+        return RateLimiter.create(15);
+    }
+}

--- a/src/main/java/muzusi/infrastructure/config/RedisConfig.java
+++ b/src/main/java/muzusi/infrastructure/config/RedisConfig.java
@@ -25,11 +25,16 @@ public class RedisConfig {
 
     @Value("${spring.data.redis.port}")
     private int port;
+    
+    @Value("${spring.data.redis.password}")
+    private String password;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(host, port);
-
+        if (!password.isBlank()) {
+            redisStandaloneConfiguration.setPassword(password);
+        }
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,7 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD}
 
     mongodb:
       host: ${MONGODB_HOST:localhost}


### PR DESCRIPTION
## 배경
- 한국투자증권 REST API 호출 유량 제한 정책 대응을 위한 Guava 라이브러리의 `RateLimiter` 전역 적용
  - 초당 20건

## 작업 사항
- 한국투자증권 API 호출 관련 `RateLimiter` 빈 등록 | (68919a66a2c512ef6b24f4e9c99c16c4774b2bcc)
  - 호출 유량 제한량과 일치하는 `20`으로 설정 시 호출 유량 제한 에러 응답이 오는 경우가 있었습니다. 이는 한국투자증권이 슬라이딩 윈도우 방식으로 쓰로틀링을 적용하고 있는 것으로 추측되며, 그로 인하여 API 호출이 일시적으로 몰리는 경우에 여전히 호출 응답 오류 발생이 가능한 것으로 추측됩니다. 
  - 따라서, 보수적으로 처리율 제한량을 `15`로 설정하였습니다.
- 한국투자증권 API 호출 로직 내 RateLimiter 빈 적용 | (5708d8917a9626009690690d4bcd6b5a502cd338)
- 환경변수 내 `REDIS_PASSWORD` 존재 시 패스워드 설정 로직 추가 | (4850582b7e5fbc8b1e1f901862fbdbd9b4eb51b6)

## 추가 논의
&nbsp; 현재 한국투자증권 API를 받아오는 작업은 다음과 같습니다.

- 한국투자증권 앱키/웹소켓접속키 발급
- 주식 현재가
- 주식 순위

&nbsp; 앱키/웹소켓 접속키 발급의 경우에는 애플리케이션 시작 시 & 주식 시장 시작 전 수행되기 때문에 호출 유량 제한이 일어날 가능성이 없기 때문에 쓰로틀링 적용하지 않았습니다.

&nbsp; 주식 순위와 주식 현재가 API 호출 작업은 주식 시장이 열리는 시간에 10분 단위로 해당 작업들이 겹쳐서 진행됩니다.

&nbsp; 주식 순위의 경우에는 10분 단위로 단 1번의 요청만 이루어지기 때문에 호출 유량 제한이 발생할 가능성은 낮지만, 아래와 같은 이유로 인하여 우선은 한국투자증권 API 호추 로직 내 `RateLimiter` 공통적으로 적용하였습니다.

- 차후 한국투자증권 API 추가 도입 시 호출 유량 제한 발생 가능성 증가
- 주식 현재가 API 호출이 우선적으로 진행되어 호출 유량 제한에 걸릴 가능성 존재

&nbsp; 위와 같은 이유들이 존재해 앱키/웹소켓접속키를 제외한 한국투자증권 API 호출 로직 내 RateLimiter를 전역적으로 설정해주었습니다.