### PR TITLE
Chore: .gitignore 내 클로드 관련 파일 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ src/main/generated
 
 ### Mac OS ###
 .DS_Store
+
+### AI: CLAUDE ###
+CLAUDE.md
+context/*


### PR DESCRIPTION
## 배경

Claude 관련 파일(CLAUDE.md, context/*)이 저장소에 커밋되지 않도록 관리할 필요가 존재

## 작업 사항

- `.gitignore`에 `CLAUDE.md`, `context/*` 추가 | (96b830cfe24882e11b7dfa1af6d832b0a0b6f880)
