### PR TITLE
Chore: develop 브랜치 대상 CI 파이프라인 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
   workflow_dispatch:
     inputs:
       logLevel:


### PR DESCRIPTION
## 배경
- 리팩토링 및 프로젝트 구조 개편을 위해 `develop` 브랜치를 default 브랜치로 설정하고자 함.
- 향후 주요 작업이 `develop` 브랜치를 기준으로 진행됨에 따라, CI 파이프라인을 구축하여 코드의 안정성을 확보하고자 함.

## 작업 사항

- `develop` 브랜치 대상 CI 워크플로우 트리거 조건 추가 | (9434fe0c4c671ecbb5944d6f7ea57bc4778dc345)
