### PR TITLE
Refact: 외부 인프라 관련 예외 및 AOP 위치 변경 리팩토링

### DIFF
--- a/src/main/java/muzusi/application/news/service/NewsManagementService.java
+++ b/src/main/java/muzusi/application/news/service/NewsManagementService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import muzusi.domain.news.entity.News;
 import muzusi.domain.news.service.NewsService;
 import muzusi.global.util.datetime.DateTimeFormatterUtil;
-import muzusi.infrastructure.news.NewsApiClient;
+import muzusi.infrastructure.news.NaverNewsApiClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,7 +14,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class NewsManagementService {
-    private final NewsApiClient newsApiClient;
+    private final NaverNewsApiClient naverNewsApiClient;
     private final NewsService newsService;
 
     private final static List<String> keywords = List.of("코스피", "코스닥");
@@ -26,7 +26,7 @@ public class NewsManagementService {
     @Transactional
     public void createPostsFromNews() {
         keywords.forEach(keyword ->
-                newsApiClient.fetchNews(keyword).stream()
+                naverNewsApiClient.fetchNews(keyword).stream()
                         .filter(content -> !newsService.existsByLink(content.get("link")))
                         .map(content ->
                                 News.builder()

--- a/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForDev.java
+++ b/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForDev.java
@@ -3,7 +3,7 @@ package muzusi.global.aop;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import muzusi.infrastructure.kis.exception.KisApiException;
-import muzusi.global.exception.KisOAuthApiException;
+import muzusi.infrastructure.kis.exception.KisOAuthApiException;
 import muzusi.global.exception.NewsApiException;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;

--- a/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForDev.java
+++ b/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForDev.java
@@ -2,7 +2,7 @@ package muzusi.global.aop;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import muzusi.global.exception.KisApiException;
+import muzusi.infrastructure.kis.exception.KisApiException;
 import muzusi.global.exception.KisOAuthApiException;
 import muzusi.global.exception.NewsApiException;
 import org.aspectj.lang.ProceedingJoinPoint;

--- a/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForDev.java
+++ b/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForDev.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import muzusi.infrastructure.kis.exception.KisApiException;
 import muzusi.infrastructure.kis.exception.KisOAuthApiException;
-import muzusi.global.exception.NewsApiException;
+import muzusi.infrastructure.news.exception.NewsApiException;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;

--- a/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForDev.java
+++ b/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForDev.java
@@ -25,12 +25,12 @@ public class ExternalApiExceptionAspectForDev {
         } catch (NewsApiException e) {
             log.error("[NEWS ERROR] {}", e.getMessage());
             throw e;
-        } catch (KisApiException e) {
-            log.error("[KIS ERROR] {}", e.getMessage());
-            throw e;
         } catch (KisOAuthApiException e) {
             log.error("[KIS OAUTH ERROR] {}", e.getMessage());
             return null;
+        } catch (KisApiException e) {
+            log.error("[KIS ERROR] {}", e.getMessage());
+            throw e;
         }
     }
 }

--- a/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForDev.java
+++ b/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForDev.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import muzusi.infrastructure.kis.exception.KisApiException;
 import muzusi.infrastructure.kis.exception.KisOAuthApiException;
-import muzusi.infrastructure.news.exception.NewsApiException;
+import muzusi.infrastructure.news.exception.NaverNewsApiException;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -22,7 +22,7 @@ public class ExternalApiExceptionAspectForDev {
     public Object handleServiceExceptions(ProceedingJoinPoint joinPoint) throws Throwable {
         try {
             return joinPoint.proceed();
-        } catch (NewsApiException e) {
+        } catch (NaverNewsApiException e) {
             log.error("[NEWS ERROR] {}", e.getMessage());
             throw e;
         } catch (KisOAuthApiException e) {

--- a/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForProd.java
+++ b/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForProd.java
@@ -32,14 +32,14 @@ public class ExternalApiExceptionAspectForProd {
             log.error("[NEWS ERROR] {}", e.getMessage());
             discordWebhookClient.sendWebhookMessage(getMessage("# NEWS ERROR", joinPoint, e));
             throw e;
-        } catch (KisApiException e) {
-            log.error("[KIS ERROR] {}", e.getMessage());
-            discordWebhookClient.sendWebhookMessage(getMessage("# KIS ERROR", joinPoint, e));
-            throw e;
         } catch (KisOAuthApiException e) {
             log.error("[KIS OAUTH ERROR] {}", e.getMessage());
             discordWebhookClient.sendWebhookMessage(getCriticalMessage("# KIS ERROR - OAuth", joinPoint, e));
             return null;
+        } catch (KisApiException e) {
+            log.error("[KIS ERROR] {}", e.getMessage());
+            discordWebhookClient.sendWebhookMessage(getMessage("# KIS ERROR", joinPoint, e));
+            throw e;
         }
     }
 

--- a/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForProd.java
+++ b/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForProd.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import muzusi.infrastructure.webhook.Embed;
 import muzusi.infrastructure.webhook.Message;
-import muzusi.global.exception.KisApiException;
+import muzusi.infrastructure.kis.exception.KisApiException;
 import muzusi.global.exception.KisOAuthApiException;
 import muzusi.global.exception.NewsApiException;
 import muzusi.infrastructure.webhook.DiscordWebhookClient;

--- a/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForProd.java
+++ b/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForProd.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import muzusi.infrastructure.webhook.Embed;
 import muzusi.infrastructure.webhook.Message;
 import muzusi.infrastructure.kis.exception.KisApiException;
-import muzusi.global.exception.KisOAuthApiException;
+import muzusi.infrastructure.kis.exception.KisOAuthApiException;
 import muzusi.global.exception.NewsApiException;
 import muzusi.infrastructure.webhook.DiscordWebhookClient;
 import org.aspectj.lang.ProceedingJoinPoint;

--- a/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForProd.java
+++ b/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForProd.java
@@ -6,7 +6,7 @@ import muzusi.infrastructure.webhook.Embed;
 import muzusi.infrastructure.webhook.Message;
 import muzusi.infrastructure.kis.exception.KisApiException;
 import muzusi.infrastructure.kis.exception.KisOAuthApiException;
-import muzusi.infrastructure.news.exception.NewsApiException;
+import muzusi.infrastructure.news.exception.NaverNewsApiException;
 import muzusi.infrastructure.webhook.DiscordWebhookClient;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -28,7 +28,7 @@ public class ExternalApiExceptionAspectForProd {
     public Object handleServiceExceptions(ProceedingJoinPoint joinPoint) throws Throwable {
         try {
             return joinPoint.proceed();
-        } catch (NewsApiException e) {
+        } catch (NaverNewsApiException e) {
             log.error("[NEWS ERROR] {}", e.getMessage());
             discordWebhookClient.sendWebhookMessage(getMessage("# NEWS ERROR", joinPoint, e));
             throw e;

--- a/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForProd.java
+++ b/src/main/java/muzusi/global/aop/ExternalApiExceptionAspectForProd.java
@@ -6,7 +6,7 @@ import muzusi.infrastructure.webhook.Embed;
 import muzusi.infrastructure.webhook.Message;
 import muzusi.infrastructure.kis.exception.KisApiException;
 import muzusi.infrastructure.kis.exception.KisOAuthApiException;
-import muzusi.global.exception.NewsApiException;
+import muzusi.infrastructure.news.exception.NewsApiException;
 import muzusi.infrastructure.webhook.DiscordWebhookClient;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;

--- a/src/main/java/muzusi/global/exception/ExternalApiException.java
+++ b/src/main/java/muzusi/global/exception/ExternalApiException.java
@@ -5,7 +5,11 @@ public class ExternalApiException extends RuntimeException {
         super(message, null, false, false);
     }
     
-    public ExternalApiException(Throwable cause, String message) {
+    public ExternalApiException(Throwable cause) {
+        super(cause.getMessage(), cause, false, false);
+    }
+    
+    public ExternalApiException(String message, Throwable cause) {
         super(message, cause, false, false);
     }
 }

--- a/src/main/java/muzusi/infrastructure/common/aop/ExternalApiExceptionAspectForDev.java
+++ b/src/main/java/muzusi/infrastructure/common/aop/ExternalApiExceptionAspectForDev.java
@@ -1,4 +1,4 @@
-package muzusi.global.aop;
+package muzusi.infrastructure.common.aop;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/muzusi/infrastructure/common/aop/ExternalApiExceptionAspectForProd.java
+++ b/src/main/java/muzusi/infrastructure/common/aop/ExternalApiExceptionAspectForProd.java
@@ -1,4 +1,4 @@
-package muzusi.global.aop;
+package muzusi.infrastructure.common.aop;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/muzusi/infrastructure/kis/auth/KisOAuthClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/auth/KisOAuthClient.java
@@ -3,7 +3,7 @@ package muzusi.infrastructure.kis.auth;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import muzusi.global.exception.KisOAuthApiException;
+import muzusi.infrastructure.kis.exception.KisOAuthApiException;
 import muzusi.infrastructure.kis.constant.KisUrlConstant;
 import muzusi.infrastructure.properties.KisProperties;
 import org.springframework.http.HttpEntity;

--- a/src/main/java/muzusi/infrastructure/kis/exception/KisApiException.java
+++ b/src/main/java/muzusi/infrastructure/kis/exception/KisApiException.java
@@ -1,8 +1,9 @@
 package muzusi.infrastructure.kis.exception;
 
-public class KisApiException extends RuntimeException {
+import muzusi.global.exception.ExternalApiException;
 
-    public KisApiException(Throwable exception) {
-        super(exception.getMessage(), null, false, false);
+public class KisApiException extends ExternalApiException {
+    public KisApiException(Throwable cause) {
+        super(cause);
     }
 }

--- a/src/main/java/muzusi/infrastructure/kis/exception/KisApiException.java
+++ b/src/main/java/muzusi/infrastructure/kis/exception/KisApiException.java
@@ -3,7 +3,15 @@ package muzusi.infrastructure.kis.exception;
 import muzusi.global.exception.ExternalApiException;
 
 public class KisApiException extends ExternalApiException {
+    public KisApiException(String message) {
+        super(message);
+    }
+    
     public KisApiException(Throwable cause) {
         super(cause);
+    }
+    
+    public KisApiException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/src/main/java/muzusi/infrastructure/kis/exception/KisApiException.java
+++ b/src/main/java/muzusi/infrastructure/kis/exception/KisApiException.java
@@ -1,4 +1,4 @@
-package muzusi.global.exception;
+package muzusi.infrastructure.kis.exception;
 
 public class KisApiException extends RuntimeException {
 

--- a/src/main/java/muzusi/infrastructure/kis/exception/KisOAuthApiException.java
+++ b/src/main/java/muzusi/infrastructure/kis/exception/KisOAuthApiException.java
@@ -1,4 +1,4 @@
-package muzusi.global.exception;
+package muzusi.infrastructure.kis.exception;
 
 public class KisOAuthApiException extends RuntimeException {
 

--- a/src/main/java/muzusi/infrastructure/kis/exception/KisOAuthApiException.java
+++ b/src/main/java/muzusi/infrastructure/kis/exception/KisOAuthApiException.java
@@ -1,8 +1,8 @@
 package muzusi.infrastructure.kis.exception;
 
-public class KisOAuthApiException extends RuntimeException {
+public class KisOAuthApiException extends KisApiException {
 
-    public KisOAuthApiException(Throwable exception) {
-        super(exception.getMessage(), null, false, false);
+    public KisOAuthApiException(Throwable cause) {
+        super(cause);
     }
 }

--- a/src/main/java/muzusi/infrastructure/kis/market/client/KisMarketOpenClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/market/client/KisMarketOpenClient.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import muzusi.global.exception.KisApiException;
+import muzusi.infrastructure.kis.exception.KisApiException;
 import muzusi.infrastructure.kis.KisRequestFactory;
 import muzusi.infrastructure.kis.constant.KisUrlConstant;
 import muzusi.infrastructure.properties.KisProperties;

--- a/src/main/java/muzusi/infrastructure/kis/ranking/KisRankingClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/ranking/KisRankingClient.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import muzusi.application.stock.dto.StockRankDto;
-import muzusi.global.exception.KisApiException;
+import muzusi.infrastructure.kis.exception.KisApiException;
 import muzusi.infrastructure.kis.KisRequestFactory;
 import muzusi.infrastructure.kis.constant.KisUrlConstant;
 import muzusi.infrastructure.properties.KisProperties;

--- a/src/main/java/muzusi/infrastructure/kis/stock/KisStockClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/stock/KisStockClient.java
@@ -3,7 +3,7 @@ package muzusi.infrastructure.kis.stock;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import muzusi.global.exception.KisApiException;
+import muzusi.infrastructure.kis.exception.KisApiException;
 import muzusi.infrastructure.kis.KisRequestFactory;
 import muzusi.infrastructure.kis.constant.KisUrlConstant;
 import muzusi.infrastructure.properties.KisProperties;

--- a/src/main/java/muzusi/infrastructure/kis/stockchart/client/KisStockChartClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/stockchart/client/KisStockChartClient.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import muzusi.application.stockchart.dto.StockChartDto;
-import muzusi.global.exception.ExternalApiException;
 import muzusi.global.util.datetime.DateTimeFormatterUtil;
 import muzusi.infrastructure.kis.KisRequestFactory;
 import muzusi.infrastructure.kis.constant.KisUrlConstant;
+import muzusi.infrastructure.kis.exception.KisApiException;
 import muzusi.infrastructure.properties.KisProperties;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -57,7 +57,7 @@ public class KisStockChartClient {
             
             return parseStockChartResponse(rootNode, gap, stockCode, time);
         } catch (Exception e) {
-            throw new ExternalApiException(e, "한국투자증권 당일분봉조회 API 호출 중 에러가 발생하였습니다.");
+            throw new KisApiException("한국투자증권 당일분봉조회 API 호출 중 에러가 발생하였습니다.", e);
         }
     }
     
@@ -74,7 +74,7 @@ public class KisStockChartClient {
         JsonNode output = rootNode.get("output2");
         
         if (output == null || output.isEmpty()) {
-            throw new ExternalApiException("한국투자증권 당일분봉조회 API 조회 결과가 비어있습니다.");
+            throw new KisApiException("한국투자증권 당일분봉조회 API 조회 결과가 비어있습니다.");
         }
         
         int windowSize = Math.min(gap, output.size());

--- a/src/main/java/muzusi/infrastructure/kis/stockprice/client/KisMultiStockPriceClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/stockprice/client/KisMultiStockPriceClient.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.RateLimiter;
 import lombok.RequiredArgsConstructor;
-import muzusi.global.exception.ExternalApiException;
 import muzusi.infrastructure.kis.KisRequestFactory;
 import muzusi.infrastructure.kis.constant.KisUrlConstant;
+import muzusi.infrastructure.kis.exception.KisApiException;
 import muzusi.infrastructure.properties.KisProperties;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -91,7 +91,7 @@ public class KisMultiStockPriceClient {
             
             return parseMultiStockPrice(rootNode);
         } catch (Exception e) {
-            throw new ExternalApiException(e, "한국투자증권 멀티종목 시세 조회 API 조회 중 오류가 발생하였습니다.");
+            throw new KisApiException("한국투자증권 멀티종목 시세 조회 API 조회 중 오류가 발생하였습니다.", e);
         }
     }
     

--- a/src/main/java/muzusi/infrastructure/news/NaverNewsApiClient.java
+++ b/src/main/java/muzusi/infrastructure/news/NaverNewsApiClient.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
 
 @Component
 @RequiredArgsConstructor
-public class NewsApiClient {
+public class NaverNewsApiClient {
     private final NewsProperties newsProperties;
     private final ObjectMapper objectMapper;
 

--- a/src/main/java/muzusi/infrastructure/news/NewsApiClient.java
+++ b/src/main/java/muzusi/infrastructure/news/NewsApiClient.java
@@ -2,7 +2,7 @@ package muzusi.infrastructure.news;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import muzusi.infrastructure.news.exception.NewsApiException;
+import muzusi.infrastructure.news.exception.NaverNewsApiException;
 import muzusi.infrastructure.properties.NewsProperties;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -57,7 +57,7 @@ public class NewsApiClient {
                     ))
                     .toList();
         } catch (Exception e) {
-            throw new NewsApiException(e);
+            throw new NaverNewsApiException(e);
         }
     }
 

--- a/src/main/java/muzusi/infrastructure/news/NewsApiClient.java
+++ b/src/main/java/muzusi/infrastructure/news/NewsApiClient.java
@@ -57,7 +57,7 @@ public class NewsApiClient {
                     ))
                     .toList();
         } catch (Exception e) {
-            throw new NaverNewsApiException(e);
+            throw new NaverNewsApiException("네이버 뉴스 조회 API 호출 중 에러가 발생하였습니다.", e);
         }
     }
 

--- a/src/main/java/muzusi/infrastructure/news/NewsApiClient.java
+++ b/src/main/java/muzusi/infrastructure/news/NewsApiClient.java
@@ -2,9 +2,7 @@ package muzusi.infrastructure.news;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import muzusi.global.exception.CustomException;
-import muzusi.global.exception.NewsApiException;
-import muzusi.global.response.error.type.CommonErrorType;
+import muzusi.infrastructure.news.exception.NewsApiException;
 import muzusi.infrastructure.properties.NewsProperties;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;

--- a/src/main/java/muzusi/infrastructure/news/exception/NaverNewsApiException.java
+++ b/src/main/java/muzusi/infrastructure/news/exception/NaverNewsApiException.java
@@ -3,7 +3,15 @@ package muzusi.infrastructure.news.exception;
 import muzusi.global.exception.ExternalApiException;
 
 public class NaverNewsApiException extends ExternalApiException {
+    public NaverNewsApiException(String message) {
+        super(message);
+    }
+    
     public NaverNewsApiException(Throwable cause) {
         super(cause);
+    }
+    
+    public NaverNewsApiException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/src/main/java/muzusi/infrastructure/news/exception/NaverNewsApiException.java
+++ b/src/main/java/muzusi/infrastructure/news/exception/NaverNewsApiException.java
@@ -2,8 +2,8 @@ package muzusi.infrastructure.news.exception;
 
 import muzusi.global.exception.ExternalApiException;
 
-public class NewsApiException extends ExternalApiException {
-    public NewsApiException(Throwable cause) {
+public class NaverNewsApiException extends ExternalApiException {
+    public NaverNewsApiException(Throwable cause) {
         super(cause);
     }
 }

--- a/src/main/java/muzusi/infrastructure/news/exception/NewsApiException.java
+++ b/src/main/java/muzusi/infrastructure/news/exception/NewsApiException.java
@@ -1,4 +1,4 @@
-package muzusi.global.exception;
+package muzusi.infrastructure.news.exception;
 
 public class NewsApiException extends RuntimeException {
 

--- a/src/main/java/muzusi/infrastructure/news/exception/NewsApiException.java
+++ b/src/main/java/muzusi/infrastructure/news/exception/NewsApiException.java
@@ -1,8 +1,9 @@
 package muzusi.infrastructure.news.exception;
 
-public class NewsApiException extends RuntimeException {
+import muzusi.global.exception.ExternalApiException;
 
-    public NewsApiException(Throwable exception) {
-        super(exception.getMessage(), null, false, false);
+public class NewsApiException extends ExternalApiException {
+    public NewsApiException(Throwable cause) {
+        super(cause);
     }
 }


### PR DESCRIPTION
## 배경
- #129 

## 작업 사항

예외 인프라에 종속적인 예외를 `global` → `infrastructure` 패키지로 이동 및 그에 따른 관련 클래스 변경

- 외부 인프라 예외 계층 구조 정의 | (713dbc996a547d490c37f2328f856ee008a5d1cc)
  - `infrastructure` 내 모든 예외는 `global.exception.ExternalApiException`을 상속한다.
  - `KisOAuthApiException`과 같이 특정 도메인 내 세부 예외를 해당 도메인의 최상단 예외(ex. `KisApiException`)를 상속한다.
  - `KisApiException` ← `KisOAuthApiException` 계층 구조에 따른 예외 처리(try-catch) 순서 변경
  - `ExternalApiException` 상속에 따른 각 예외 클래스 내 생성자 추가 | (a3b28660dd4c6c7cf7b0ad2f1927f1ac29537724)
- `KisApiException` & `KisOAuthApiException`
  - 패키지 위치 변경: `global.exception` → `infrastructure.kis.exception` | (a9881d68d3ed66bc51ea90990ddd2ca61d651b8d) (d762b2cd15dbed27b4af9aaae9f33d043daed937)
  - 
- `NewApiException`
  - 패키지 위치 변경: `globalException` → `infrastructure.news.exception` | (9d60d1fa2e65e0b31adefa583e208397d1b285a4)
  - 클래스명 변경: `NewsApiException` → `NaverNewsApiException` | (21e7b84a20f1d3f351720f18b8ba03562d97295a)
<!---->
- `NewsApiClient`
  - 클래스명 변경: `NewsClient` → `NaverNewsApiClient` | (ab297898dc8ab21f0545712d911fcb0b281f2bfd)
- 예외 로깅 및 웹훅 AOP 위치 변경 | (cca9c543caf97c442d7926873f421b17a994623c)
  - `global.aop` → `infrastructure.common.aop`