### PR TITLE
Refact: 한국투자증권 호출 유량 제어 로직 리팩토링

### DIFF
--- a/src/main/java/muzusi/application/stockchart/service/StockMinutesChartUpdater.java
+++ b/src/main/java/muzusi/application/stockchart/service/StockMinutesChartUpdater.java
@@ -29,7 +29,6 @@ public class StockMinutesChartUpdater {
     private final FetchStockChartPort fetchStockChartPort;
     private final StockMinutesService stockMinutesService;
     private final StockPriceService stockPriceService;
-    private final RateLimiter kisRateLimiter; // TODO: 향후 infrastructure 레이어로 분리
     
     private static final int CHART_MINUTES_GAP = 10;
     private static final int BATCH_SIZE = 500;
@@ -50,8 +49,6 @@ public class StockMinutesChartUpdater {
         
         for (String stockCode: stockCodePort.getAllStockCodes()) {
             try {
-                kisRateLimiter.acquire();
-                
                 StockChartDto stockChart = fetchStockChartPort.getStockMinutesChart(stockCode, now, CHART_MINUTES_GAP);
                 stockChartMap.put(stockCode, stockChart);
             } catch (Exception exception) {

--- a/src/main/java/muzusi/application/stockranking/service/StockRankingUpdater.java
+++ b/src/main/java/muzusi/application/stockranking/service/StockRankingUpdater.java
@@ -16,8 +16,6 @@ import java.util.List;
 public class StockRankingUpdater {
     private final FetchStockRankingPort fetchStockRankingPort;
     private final StockRankingService stockRankingService;
-    private final RateLimiter kisRateLimiter; // TODO: 향후 infrastructure 레이어로 이동
-
     /**
      * 주식 순위 포트를 통한 주식 거래량 순위 데이터 수집 후, 주식 거래량 순위를 갱신하는 메서드
      *
@@ -25,8 +23,6 @@ public class StockRankingUpdater {
      * <p> 주식 거래량 순위를 저장할 때, 갱신 시간도 같이 저장한다.
      */
     public void updateVolumeRank() {
-        kisRateLimiter.acquire();
-
         List<StockRankDto> volumeRank = fetchStockRankingPort.getVolumeRank();
         stockRankingService.deleteVolumeRankingCache();
         stockRankingService.setVolumeRankingInCache(volumeRank);
@@ -40,8 +36,6 @@ public class StockRankingUpdater {
      * <p> 주식 급등락 순위를 저장할 때, 갱신 시간도 같이 저장한다.
      */
     public void updateFluctuationRank() {
-        kisRateLimiter.acquire();
-
         List<StockRankDto> risingStockRanking = fetchStockRankingPort.getRisingFluctuationRank();
         List<StockRankDto> fallingStockRanking = fetchStockRankingPort.getFallingFluctuationRank();
 

--- a/src/main/java/muzusi/infrastructure/config/GuavaConfig.java
+++ b/src/main/java/muzusi/infrastructure/config/GuavaConfig.java
@@ -6,9 +6,14 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class GuavaConfig {
+    /**
+     * 한국투자증권 REST API 호출 유량 제한: 초당 20 건
+     * <p> 안전 마진을 적용하여 초당 15회의 요청만 가능하도록 제한
+     */
+    private static final int RATE_LIMIT = 15;
 
     @Bean
     public RateLimiter kisRateLimiter() {
-        return RateLimiter.create(15);
+        return RateLimiter.create(RATE_LIMIT);
     }
 }

--- a/src/main/java/muzusi/infrastructure/kis/aop/KisRateLimit.java
+++ b/src/main/java/muzusi/infrastructure/kis/aop/KisRateLimit.java
@@ -1,0 +1,11 @@
+package muzusi.infrastructure.kis.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface KisRateLimit {
+}

--- a/src/main/java/muzusi/infrastructure/kis/aop/KisRateLimitAspect.java
+++ b/src/main/java/muzusi/infrastructure/kis/aop/KisRateLimitAspect.java
@@ -1,0 +1,22 @@
+package muzusi.infrastructure.kis.aop;
+
+import com.google.common.util.concurrent.RateLimiter;
+import lombok.RequiredArgsConstructor;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class KisRateLimitAspect {
+    private final RateLimiter kisRateLimiter;
+    
+    @Around("@annotation(muzusi.infrastructure.kis.aop.KisRateLimit)")
+    public Object aroundRateLimit(ProceedingJoinPoint joinPoint) throws Throwable {
+        kisRateLimiter.acquire();
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/muzusi/infrastructure/kis/auth/KisOAuthClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/auth/KisOAuthClient.java
@@ -3,6 +3,7 @@ package muzusi.infrastructure.kis.auth;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import muzusi.infrastructure.kis.aop.KisRateLimit;
 import muzusi.infrastructure.kis.exception.KisOAuthApiException;
 import muzusi.infrastructure.kis.constant.KisUrlConstant;
 import muzusi.infrastructure.properties.KisProperties;
@@ -32,6 +33,7 @@ public class KisOAuthClient {
      * @param appSecret 한국투자증권 앱시크릿
      * @return          한국투자증권 접근 토큰 {@code "type value"} (ex. {@code "Bearer xxx"})
      */
+    @KisRateLimit
     public String getAccessToken(String appKey, String appSecret) {
         Map<String, String> body = new HashMap<>();
         body.put("grant_type", "client_credentials");
@@ -53,6 +55,7 @@ public class KisOAuthClient {
      * @param appSecret 한국투자증권 앱시크릿
      * @return          한국투자증권 웹소켓 접속키
      */
+    @KisRateLimit
     public String getWebSocketKey(String appKey, String appSecret) {
         Map<String, String> body = new HashMap<>();
         body.put("grant_type", "client_credentials");

--- a/src/main/java/muzusi/infrastructure/kis/market/client/KisMarketOpenClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/market/client/KisMarketOpenClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import muzusi.infrastructure.kis.aop.KisRateLimit;
 import muzusi.infrastructure.kis.exception.KisApiException;
 import muzusi.infrastructure.kis.KisRequestFactory;
 import muzusi.infrastructure.kis.constant.KisUrlConstant;
@@ -30,6 +31,7 @@ public class KisMarketOpenClient {
     
     private static final String TR_ID = "CTCA0903R";
     
+    @KisRateLimit
     public boolean isMarketOpen() {
         HttpHeaders header = kisRequestFactory.getHttpHeader(TR_ID);
         

--- a/src/main/java/muzusi/infrastructure/kis/ranking/KisRankingClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/ranking/KisRankingClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import muzusi.application.stock.dto.StockRankDto;
+import muzusi.infrastructure.kis.aop.KisRateLimit;
 import muzusi.infrastructure.kis.exception.KisApiException;
 import muzusi.infrastructure.kis.KisRequestFactory;
 import muzusi.infrastructure.kis.constant.KisUrlConstant;
@@ -29,6 +30,7 @@ public class KisRankingClient {
     private final static String VOLUME_RANK_TR_ID = "FHPST01710000";
     private final static String FLUCTUATION_RANK_TR_ID = "FHPST01700000";
 
+    @KisRateLimit
     public List<StockRankDto> getVolumeRank() {
         HttpHeaders headers = kisRequestFactory.getHttpHeader(VOLUME_RANK_TR_ID);
 
@@ -77,10 +79,12 @@ public class KisRankingClient {
         }
     }
 
+    @KisRateLimit
     public List<StockRankDto> getRisingFluctuationRank() {
         return getFluctuationRank("0");
     }
 
+    @KisRateLimit
     public List<StockRankDto> getFallingFluctuationRank() {
         return getFluctuationRank("1");
     }

--- a/src/main/java/muzusi/infrastructure/kis/stockchart/client/KisStockChartClient.java
+++ b/src/main/java/muzusi/infrastructure/kis/stockchart/client/KisStockChartClient.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import muzusi.application.stockchart.dto.StockChartDto;
 import muzusi.global.util.datetime.DateTimeFormatterUtil;
 import muzusi.infrastructure.kis.KisRequestFactory;
+import muzusi.infrastructure.kis.aop.KisRateLimit;
 import muzusi.infrastructure.kis.constant.KisUrlConstant;
 import muzusi.infrastructure.kis.exception.KisApiException;
 import muzusi.infrastructure.properties.KisProperties;
@@ -30,6 +31,7 @@ public class KisStockChartClient {
     private static final String STOCK_MINUTES_CHART_TR_ID = "FHKST03010200";
     private static final DateTimeFormatter HHMMSS_FORMATTER = DateTimeFormatter.ofPattern("HHmmss");
     
+    @KisRateLimit
     public StockChartDto getStockMinutesChart(String stockCode, LocalDateTime time, int gap) {
         HttpHeaders headers = requestFactory.getHttpHeader(STOCK_MINUTES_CHART_TR_ID);
         

--- a/src/test/java/muzusi/application/stockchart/service/StockMinutesChartUpdaterTest.java
+++ b/src/test/java/muzusi/application/stockchart/service/StockMinutesChartUpdaterTest.java
@@ -1,6 +1,5 @@
 package muzusi.application.stockchart.service;
 
-import com.google.common.util.concurrent.RateLimiter;
 import muzusi.application.stockchart.dto.StockChartDto;
 import muzusi.application.stockchart.port.FetchStockChartPort;
 import muzusi.application.stockcode.port.StockCodePort;
@@ -46,9 +45,6 @@ class StockMinutesChartUpdaterTest {
     @Mock
     private StockPriceService stockPriceService;
 
-    @Mock
-    private RateLimiter kisRateLimiter;
-
     @InjectMocks
     private StockMinutesChartUpdater stockMinutesChartUpdater;
 
@@ -88,7 +84,6 @@ class StockMinutesChartUpdaterTest {
         }
 
         // then
-        verify(kisRateLimiter, times(2)).acquire();
         verify(stockMinutesService).saveAllInCache(argThat(charts ->
                 charts.size() == 2 && charts.containsAll(List.of(samsungChart, skHynixChart))));
         verify(stockPriceService).saveAllInCache(argThat((Map<String, Object> priceMap) ->
@@ -113,7 +108,6 @@ class StockMinutesChartUpdaterTest {
         stockMinutesChartUpdater.updateStockMinutesChart();
 
         // then
-        verify(kisRateLimiter, times(1)).acquire();
         verify(fetchStockChartPort, times(2))
                 .getStockMinutesChart(eq("005930"), any(), eq(10));
         verify(stockMinutesService).saveAllInCache(argThat(charts ->
@@ -137,7 +131,6 @@ class StockMinutesChartUpdaterTest {
         stockMinutesChartUpdater.updateStockMinutesChart();
 
         // then
-        verify(kisRateLimiter, times(2)).acquire();
         verify(stockMinutesService).saveAllInCache(argThat(charts ->
                 charts.size() == 1 && charts.contains(skHynixChart)));
     }

--- a/src/test/java/muzusi/application/stockranking/service/StockRankingUpdaterTest.java
+++ b/src/test/java/muzusi/application/stockranking/service/StockRankingUpdaterTest.java
@@ -1,6 +1,5 @@
 package muzusi.application.stockranking.service;
 
-import com.google.common.util.concurrent.RateLimiter;
 import muzusi.application.stock.dto.StockRankDto;
 import muzusi.application.stockranking.port.FetchStockRankingPort;
 import muzusi.domain.stock.service.StockRankingService;
@@ -18,7 +17,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,9 +27,6 @@ class StockRankingUpdaterTest {
 
     @Mock
     private StockRankingService stockRankingService;
-
-    @Mock
-    private RateLimiter kisRateLimiter;
 
     @InjectMocks
     private StockRankingUpdater stockRankingUpdater;
@@ -64,7 +59,6 @@ class StockRankingUpdaterTest {
             stockRankingUpdater.updateVolumeRank();
 
             // then
-            verify(kisRateLimiter, times(1)).acquire();
             verify(fetchStockRankingPort).getVolumeRank();
             verify(stockRankingService).deleteVolumeRankingCache();
             verify(stockRankingService).setVolumeRankingInCache(volumeRank);
@@ -91,7 +85,6 @@ class StockRankingUpdaterTest {
             stockRankingUpdater.updateFluctuationRank();
 
             // then
-            verify(kisRateLimiter, times(1)).acquire();
             verify(fetchStockRankingPort).getRisingFluctuationRank();
             verify(fetchStockRankingPort).getFallingFluctuationRank();
             verify(stockRankingService).deleteRisingRankingInCache();

--- a/src/test/java/muzusi/infrastructure/kis/aop/KisRateLimitAspectTest.java
+++ b/src/test/java/muzusi/infrastructure/kis/aop/KisRateLimitAspectTest.java
@@ -1,0 +1,77 @@
+package muzusi.infrastructure.kis.aop;
+
+import com.google.common.util.concurrent.RateLimiter;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class KisRateLimitAspectTest {
+
+    @Mock
+    private RateLimiter kisRateLimiter;
+
+    @Mock
+    private ProceedingJoinPoint joinPoint;
+
+    @InjectMocks
+    private KisRateLimitAspect kisRateLimitAspect;
+
+    @Nested
+    @DisplayName("유량 제한 적용")
+    class AroundRateLimit {
+        @Test
+        @DisplayName("acquire를 먼저 호출한 뒤 실제 메서드를 실행한다")
+        void successAcquireBeforeProceed() throws Throwable {
+            // given
+            when(joinPoint.proceed()).thenReturn("result");
+
+            // when
+            Object result = kisRateLimitAspect.aroundRateLimit(joinPoint);
+
+            // then
+            InOrder order = inOrder(kisRateLimiter, joinPoint);
+            order.verify(kisRateLimiter).acquire();
+            order.verify(joinPoint).proceed();
+            assertThat(result).isEqualTo("result");
+        }
+
+        @Test
+        @DisplayName("실제 메서드의 반환값을 그대로 반환한다")
+        void successReturnProceedResult() throws Throwable {
+            // given
+            when(joinPoint.proceed()).thenReturn(42L);
+
+            // when
+            Object result = kisRateLimitAspect.aroundRateLimit(joinPoint);
+
+            // then
+            assertThat(result).isEqualTo(42L);
+        }
+
+        @Test
+        @DisplayName("실제 메서드에서 예외가 발생하면 그대로 전파한다")
+        void failPropagateExceptionFromProceed() throws Throwable {
+            // given
+            IllegalStateException exception = new IllegalStateException("api error");
+            when(joinPoint.proceed()).thenThrow(exception);
+
+            // when & then
+            assertThatThrownBy(() -> kisRateLimitAspect.aroundRateLimit(joinPoint))
+                    .isSameAs(exception);
+            verify(kisRateLimiter).acquire();
+        }
+    }
+}

--- a/src/test/java/muzusi/infrastructure/kis/aop/KisRateLimiterAspectWeavingTest.java
+++ b/src/test/java/muzusi/infrastructure/kis/aop/KisRateLimiterAspectWeavingTest.java
@@ -1,0 +1,81 @@
+package muzusi.infrastructure.kis.aop;
+
+import com.google.common.util.concurrent.RateLimiter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class KisRateLimiterAspectWeavingTest {
+
+    @Mock
+    private RateLimiter kisRateLimiter;
+
+    @Nested
+    @DisplayName("@KisRateLimit 위빙")
+    class Weaving {
+        @Test
+        @DisplayName("@KisRateLimit이 붙은 메서드를 호출하면 acquire가 호출된다")
+        void successAcquireCalledOnAnnotatedMethod() {
+            // given
+            TestTarget proxy = createProxy();
+
+            // when
+            proxy.annotatedMethod();
+
+            // then
+            verify(kisRateLimiter, times(1)).acquire();
+        }
+
+        @Test
+        @DisplayName("@KisRateLimit이 없는 메서드를 호출하면 acquire가 호출되지 않는다")
+        void successAcquireNotCalledOnPlainMethod() {
+            // given
+            TestTarget proxy = createProxy();
+
+            // when
+            proxy.plainMethod();
+
+            // then
+            verify(kisRateLimiter, never()).acquire();
+        }
+
+        @Test
+        @DisplayName("애노테이션이 붙은 메서드를 여러 번 호출하면 호출 횟수만큼 acquire가 호출된다")
+        void successAcquireCalledPerInvocation() {
+            // given
+            TestTarget proxy = createProxy();
+
+            // when
+            proxy.annotatedMethod();
+            proxy.annotatedMethod();
+            proxy.annotatedMethod();
+
+            // then
+            verify(kisRateLimiter, times(3)).acquire();
+        }
+    }
+
+    private TestTarget createProxy() {
+        AspectJProxyFactory factory = new AspectJProxyFactory(new TestTarget());
+        factory.addAspect(new KisRateLimitAspect(kisRateLimiter));
+        return factory.getProxy();
+    }
+
+    static class TestTarget {
+        @KisRateLimit
+        public void annotatedMethod() {
+        }
+
+        public void plainMethod() {
+        }
+    }
+}


### PR DESCRIPTION
## 배경

- #131 

## 작업 사항

- `kisRateLimiter` 빈 호출 제어량 상수 적용 및 주석 작성 | (0c4fecaaf5aa96233bf5280646d08ce1ed13de16)
- 한국투자증권 호출 유량 제어 어노테이션 및 Aspect 적용 | (3eaed35d93fadbc2ba50db1ecb348cd940a5b1ee) (f71d78e1264d16f14b7304f637b80d644a1cf344)
  - 어노테이션: `@KisRateLimit` / Aspect: `KisRateLimitAspect`
- 한국투자증권 REST API 호출 클라이언트 클래스 내 `@KisRateLimit` 어노테이션 적용 | (66d7b218a63d45e081d9b9cbe12c0846b4b96a08) (d61044380c369f92e9ba92463878710b19d78e77)
  - 기존 유즈케이스 내 `kisRateLimiter` 빈에 대한 의존성을 제거