### PR TITLE
Refact: 뉴스 저장 및 삭제 로직 리팩토링

### DIFF
--- a/src/main/java/muzusi/application/news/port/FetchNewsPort.java
+++ b/src/main/java/muzusi/application/news/port/FetchNewsPort.java
@@ -1,0 +1,8 @@
+package muzusi.application.news.port;
+
+import java.util.List;
+import java.util.Map;
+
+public interface FetchNewsPort {
+    List<Map<String, String>> getNews(String query);
+}

--- a/src/main/java/muzusi/application/news/service/NewsManagementService.java
+++ b/src/main/java/muzusi/application/news/service/NewsManagementService.java
@@ -24,8 +24,9 @@ public class NewsManagementService {
     private final NewsService newsService;
 
     /**
-     * 뉴스 API 호출 및 저장 메서드
-     * 키워드에 맞게 뉴스 API를 호출한 후, DB에 존재 여부를 확인하고 저장을 진행한다.
+     * 뉴스 수집 및 저장 메서드
+     *
+     * <p> 키워드별로 뉴스를 수집한 후, DB에 존재 여부 및 중복 여부를 확인하고 저장을 진행한다.
      */
     @Transactional
     public void createPostsFromNews() {

--- a/src/main/java/muzusi/application/news/service/NewsManagementService.java
+++ b/src/main/java/muzusi/application/news/service/NewsManagementService.java
@@ -56,8 +56,9 @@ public class NewsManagementService {
     }
     
     /**
-     * 오래된 뉴스를 삭제하는 메서드.
-     * 1일이 지난 뉴스들을 삭제한다.
+     * 오래된 뉴스를 삭제하는 메서드
+     *
+     * <p> 보관기간({@link #NEWS_RETENTION_DAYS})이 지난 뉴스들을 삭제한다.
      */
     @Transactional
     public void deleteNews() {

--- a/src/main/java/muzusi/application/news/service/NewsManagementService.java
+++ b/src/main/java/muzusi/application/news/service/NewsManagementService.java
@@ -1,23 +1,27 @@
 package muzusi.application.news.service;
 
 import lombok.RequiredArgsConstructor;
+import muzusi.application.news.port.FetchNewsPort;
 import muzusi.domain.news.entity.News;
 import muzusi.domain.news.service.NewsService;
+import muzusi.domain.news.type.KeywordType;
 import muzusi.global.util.datetime.DateTimeFormatterUtil;
-import muzusi.infrastructure.news.NaverNewsApiClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 public class NewsManagementService {
-    private final NaverNewsApiClient naverNewsApiClient;
+    private final FetchNewsPort fetchNewsPort;
     private final NewsService newsService;
-
-    private final static List<String> keywords = List.of("코스피", "코스닥");
 
     /**
      * 뉴스 API 호출 및 저장 메서드
@@ -25,21 +29,29 @@ public class NewsManagementService {
      */
     @Transactional
     public void createPostsFromNews() {
-        keywords.forEach(keyword ->
-                naverNewsApiClient.fetchNews(keyword).stream()
-                        .filter(content -> !newsService.existsByLink(content.get("link")))
-                        .map(content ->
-                                News.builder()
-                                        .title(content.get("title"))
-                                        .link(content.get("link"))
-                                        .keyword(keyword)
-                                        .pubDate(DateTimeFormatterUtil.parseToLocalDateTime(content.get("pubDate")))
-                                        .build()
-                        )
-                        .forEach(newsService::save)
+        List<News> recentNews = new ArrayList<>();
+        Set<String> addedNewsLink = new HashSet<>();
+        
+        Arrays.stream(KeywordType.values()).forEach(
+                keyword -> {
+                    List<Map<String, String>> newsItems = fetchNewsPort.getNews(keyword.getName());
+                    
+                    newsItems.stream()
+                            .filter(news -> !newsService.existsByLink(news.get("link")))
+                            .filter(news -> addedNewsLink.add(news.get("link")))
+                            .map(news -> News.builder()
+                                    .title(news.get("title"))
+                                    .link(news.get("link"))
+                                    .keyword(keyword.getName())
+                                    .pubDate(DateTimeFormatterUtil.parseToLocalDateTime(news.get("pubDate")))
+                                    .build())
+                            .forEach(recentNews::add);
+                }
         );
+        
+        newsService.addAll(recentNews);
     }
-
+    
     /**
      * 오래된 뉴스를 삭제하는 메서드.
      * 1일이 지난 뉴스들을 삭제한다.

--- a/src/main/java/muzusi/application/news/service/NewsManagementService.java
+++ b/src/main/java/muzusi/application/news/service/NewsManagementService.java
@@ -22,6 +22,8 @@ import java.util.Set;
 public class NewsManagementService {
     private final FetchNewsPort fetchNewsPort;
     private final NewsService newsService;
+    
+    private static final int NEWS_RETENTION_DAYS = 1;
 
     /**
      * 뉴스 수집 및 저장 메서드
@@ -59,7 +61,7 @@ public class NewsManagementService {
      */
     @Transactional
     public void deleteNews() {
-        LocalDateTime dateTime = LocalDateTime.now().minusDays(1);
+        LocalDateTime dateTime = LocalDateTime.now().minusDays(NEWS_RETENTION_DAYS);
         newsService.deleteByDateTime(dateTime);
     }
 }

--- a/src/main/java/muzusi/domain/news/service/NewsService.java
+++ b/src/main/java/muzusi/domain/news/service/NewsService.java
@@ -34,4 +34,8 @@ public class NewsService {
     public void deleteByDateTime(LocalDateTime dateTime) {
         newsRepository.deleteByDateTimeBefore(dateTime);
     }
+    
+    public void addAll(List<News> recentNews) {
+        newsRepository.saveAll(recentNews);
+    }
 }

--- a/src/main/java/muzusi/infrastructure/news/adapter/NaverFetchNewsAdapter.java
+++ b/src/main/java/muzusi/infrastructure/news/adapter/NaverFetchNewsAdapter.java
@@ -1,0 +1,26 @@
+package muzusi.infrastructure.news.adapter;
+
+import lombok.RequiredArgsConstructor;
+import muzusi.application.news.port.FetchNewsPort;
+import muzusi.infrastructure.news.client.NaverNewsApiClient;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class NaverFetchNewsAdapter implements FetchNewsPort {
+    private final NaverNewsApiClient naverNewsClient;
+    
+    /**
+     * 네이버 뉴스 검색 API를 통해 주어진 검색어의 검색 결과 뉴스 목록을 반환하는 메서드
+     *
+     * @param query     검색어
+     * @return          뉴스 목록
+     */
+    @Override
+    public List<Map<String, String>> getNews(String query) {
+        return naverNewsClient.fetchNews(query);
+    }
+}

--- a/src/main/java/muzusi/infrastructure/news/client/NaverNewsApiClient.java
+++ b/src/main/java/muzusi/infrastructure/news/client/NaverNewsApiClient.java
@@ -1,4 +1,4 @@
-package muzusi.infrastructure.news;
+package muzusi.infrastructure.news.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/muzusi/application/news/service/NewsManagementServiceTest.java
+++ b/src/test/java/muzusi/application/news/service/NewsManagementServiceTest.java
@@ -1,0 +1,153 @@
+package muzusi.application.news.service;
+
+import muzusi.application.news.port.FetchNewsPort;
+import muzusi.domain.news.entity.News;
+import muzusi.domain.news.service.NewsService;
+import muzusi.domain.news.type.KeywordType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NewsManagementServiceTest {
+    @Mock
+    private FetchNewsPort fetchNewsPort;
+
+    @Mock
+    private NewsService newsService;
+
+    @InjectMocks
+    private NewsManagementService newsManagementService;
+
+    @Nested
+    @DisplayName("뉴스 수집 및 저장")
+    class CreatePostsFromNews {
+        @Test
+        @DisplayName("이미 DB에 존재하는 링크의 뉴스는 저장 대상에서 제외한다")
+        void excludeNewsAlreadyExistsInDb() {
+            // given
+            Map<String, String> existingNews = Map.of(
+                    "title", "이미 존재하는 뉴스",
+                    "link", "https://news.test/existing",
+                    "pubDate", "Mon, 30 Dec 2024 20:14:00 +0900"
+            );
+            when(fetchNewsPort.getNews(KeywordType.KOSPI.getName())).thenReturn(List.of(existingNews));
+            when(fetchNewsPort.getNews(KeywordType.KOSDAQ.getName())).thenReturn(List.of());
+            when(newsService.existsByLink("https://news.test/existing")).thenReturn(true);
+
+            // when
+            newsManagementService.createPostsFromNews();
+
+            // then
+            ArgumentCaptor<List<News>> captor = ArgumentCaptor.forClass(List.class);
+            verify(newsService).addAll(captor.capture());
+            assertThat(captor.getValue()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("서로 다른 키워드 조회 결과에 동일한 링크가 있으면 한 번만 저장한다")
+        void excludeDuplicatedLinkAcrossKeywords() {
+            // given
+            Map<String, String> duplicatedNews = Map.of(
+                    "title", "코스피/코스닥 공통 뉴스",
+                    "link", "https://news.test/duplicated",
+                    "pubDate", "Mon, 30 Dec 2024 20:14:00 +0900"
+            );
+            when(fetchNewsPort.getNews(KeywordType.KOSPI.getName())).thenReturn(List.of(duplicatedNews));
+            when(fetchNewsPort.getNews(KeywordType.KOSDAQ.getName())).thenReturn(List.of(duplicatedNews));
+            when(newsService.existsByLink("https://news.test/duplicated")).thenReturn(false);
+
+            // when
+            newsManagementService.createPostsFromNews();
+
+            // then
+            ArgumentCaptor<List<News>> captor = ArgumentCaptor.forClass(List.class);
+            verify(newsService).addAll(captor.capture());
+            assertThat(captor.getValue())
+                    .extracting(News::getLink)
+                    .containsExactly("https://news.test/duplicated");
+        }
+
+        @Test
+        @DisplayName("DB에도 없고 중복도 아닌 신규 뉴스는 키워드 정보와 함께 저장한다")
+        void saveNewNewsWithKeyword() {
+            // given
+            Map<String, String> kospiNews = Map.of(
+                    "title", "코스피 뉴스",
+                    "link", "https://news.test/kospi",
+                    "pubDate", "Mon, 30 Dec 2024 20:14:00 +0900"
+            );
+            Map<String, String> kosdaqNews = Map.of(
+                    "title", "코스닥 뉴스",
+                    "link", "https://news.test/kosdaq",
+                    "pubDate", "Tue, 31 Dec 2024 09:00:00 +0900"
+            );
+            when(fetchNewsPort.getNews(KeywordType.KOSPI.getName())).thenReturn(List.of(kospiNews));
+            when(fetchNewsPort.getNews(KeywordType.KOSDAQ.getName())).thenReturn(List.of(kosdaqNews));
+            when(newsService.existsByLink(any())).thenReturn(false);
+
+            // when
+            newsManagementService.createPostsFromNews();
+
+            // then
+            ArgumentCaptor<List<News>> captor = ArgumentCaptor.forClass(List.class);
+            verify(newsService).addAll(captor.capture());
+            assertThat(captor.getValue())
+                    .extracting(News::getTitle, News::getLink, News::getKeyword)
+                    .containsExactlyInAnyOrder(
+                            tuple("코스피 뉴스", "https://news.test/kospi", KeywordType.KOSPI.getName()),
+                            tuple("코스닥 뉴스", "https://news.test/kosdaq", KeywordType.KOSDAQ.getName())
+                    );
+        }
+
+        @Test
+        @DisplayName("조회된 뉴스가 없으면 저장을 요청하지 않고 빈 목록을 전달한다")
+        void saveEmptyListWhenNoNewsFetched() {
+            // given
+            when(fetchNewsPort.getNews(any())).thenReturn(List.of());
+
+            // when
+            newsManagementService.createPostsFromNews();
+
+            // then
+            ArgumentCaptor<List<News>> captor = ArgumentCaptor.forClass(List.class);
+            verify(newsService).addAll(captor.capture());
+            assertThat(captor.getValue()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("오래된 뉴스 삭제")
+    class DeleteNews {
+        @Test
+        @DisplayName("보관기간이 지난 뉴스 삭제를 요청한다")
+        void requestDeleteNewsBeforeRetentionPeriod() {
+            // given
+            LocalDateTime before = LocalDateTime.now().minusDays(1);
+
+            // when
+            newsManagementService.deleteNews();
+
+            // then
+            LocalDateTime after = LocalDateTime.now().minusDays(1);
+            ArgumentCaptor<LocalDateTime> captor = ArgumentCaptor.forClass(LocalDateTime.class);
+            verify(newsService).deleteByDateTime(captor.capture());
+            assertThat(captor.getValue()).isBetween(before, after);
+        }
+    }
+}

--- a/src/test/java/muzusi/infrastructure/news/adapter/NaverFetchNewsAdapterTest.java
+++ b/src/test/java/muzusi/infrastructure/news/adapter/NaverFetchNewsAdapterTest.java
@@ -1,0 +1,63 @@
+package muzusi.infrastructure.news.adapter;
+
+import muzusi.infrastructure.news.client.NaverNewsApiClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NaverFetchNewsAdapterTest {
+    @Mock
+    private NaverNewsApiClient naverNewsClient;
+
+    @InjectMocks
+    private NaverFetchNewsAdapter naverFetchNewsAdapter;
+
+    @Nested
+    @DisplayName("뉴스 조회")
+    class GetNews {
+        @Test
+        @DisplayName("검색어로 네이버 뉴스 API를 호출하고, 조회된 뉴스 목록을 그대로 반환한다")
+        void successReturnNewsList() {
+            // given
+            String query = "코스피";
+            List<Map<String, String>> newsItems = List.of(
+                    Map.of("title", "제목1", "link", "https://news.test/1", "pubDate", "2026-08-25T00:00:00")
+            );
+            when(naverNewsClient.fetchNews(query)).thenReturn(newsItems);
+
+            // when
+            List<Map<String, String>> result = naverFetchNewsAdapter.getNews(query);
+
+            // then
+            assertThat(result).isEqualTo(newsItems);
+            verify(naverNewsClient).fetchNews(query);
+        }
+
+        @Test
+        @DisplayName("조회된 뉴스가 없으면 빈 목록을 반환한다")
+        void successReturnEmptyListWhenNoNews() {
+            // given
+            String query = "코스닥";
+            when(naverNewsClient.fetchNews(query)).thenReturn(List.of());
+
+            // when
+            List<Map<String, String>> result = naverFetchNewsAdapter.getNews(query);
+
+            // then
+            assertThat(result).isEmpty();
+            verify(naverNewsClient).fetchNews(query);
+        }
+    }
+}


### PR DESCRIPTION
## 배경
- #136 

## 작업 사항
- `NaverNewsApiClient` 패키지 위치 변경 | (3cbd6fe06f8eb37e75ecfd77f80097403a01391c)
  - infrastructure.news → infrastructure.news.client
- 네이버 뉴스 조회 Port & Adapter 정의 | (5575ec60c576d90f3eb07db928de127d564cb6bf) (55104c72ed0bb315cc8af091831847ebd204b405)
  - `FetchNewsPort` - `NaverFetchNewsAdapter`
- 뉴스 수집 & 저장 로직 리팩토링 | (5c0d9ce2e610ceb227602677bf4103e8c00d3824) (b45fe05079af17ff42af5fc296c6c7f1aca526cc)
  - Port 적용
  - `List.addAll(...)`을 통하여 수집한 뉴스를 한번에 DB에 삽입
- 오래된 뉴스 삭제 로직 리팩토링
  - 뉴스 보관 기간 상수 `NEWS_RETENTION_DAYS` 지정 | (b67c2c4e2e5976ea9e131a960fedb71890be4e97) (2b80e1cec664b1a1447a1829a951f5e96d0b91f8)
- `NewsManagermentService` 테스트 코드 작성 | (c2be811a92d70d3205fe09a194ad149e10dfd854)


## 추가 논의
- 현재 `NaverNewsApliClient.fetchNews(...)`의 반환값은 `List<Map<String, String>>` 입니다. 향후 `News` 도메인 엔티티 도입 및 적용 시점에서 수정 계획입니다.