### PR TITLE
Refact: 한국투자증권 웹소켓 메시지 처리 핸들러 구조 개선

### DIFF
--- a/src/main/java/muzusi/application/trade/dto/TradeNotificationDto.java
+++ b/src/main/java/muzusi/application/trade/dto/TradeNotificationDto.java
@@ -8,8 +8,8 @@ public record TradeNotificationDto(
     String stockCode,
     String time,
     Long price,
-    Long stockCount,
-    Long volume,
+    Long contingentVolume,
+    Long accumulatedVolume,
     TradeType tradeType,
     Double changeRate
 ) {

--- a/src/main/java/muzusi/infrastructure/kis/websocket/KisWebSocketConnector.java
+++ b/src/main/java/muzusi/infrastructure/kis/websocket/KisWebSocketConnector.java
@@ -1,8 +1,9 @@
 package muzusi.infrastructure.kis.websocket;
 
 import lombok.extern.slf4j.Slf4j;
+import muzusi.infrastructure.kis.exception.KisApiException;
+import muzusi.infrastructure.kis.websocket.handler.KisWebSocketDispatcher;
 import muzusi.infrastructure.properties.KisProperties;
-import muzusi.infrastructure.stockquote.websocket.kis.KisStockQuoteWebSocketHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.client.WebSocketClient;
@@ -12,31 +13,32 @@ import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 @Component
 public class KisWebSocketConnector {
     private final WebSocketClient webSocketClient = new StandardWebSocketClient();
-    private final KisStockQuoteWebSocketHandler kisStockQuoteWebSocketHandler;
+    private final KisWebSocketDispatcher kisWebSocketDispatcher;
     private final String webSocketDomain;
     
     public KisWebSocketConnector(
             KisProperties kisProperties,
-            KisStockQuoteWebSocketHandler kisStockQuoteWebSocketHandler
+            KisWebSocketDispatcher kisWebSocketDispatcher
     ) {
         this.webSocketDomain = kisProperties.getWebSocketDomain();
-        this.kisStockQuoteWebSocketHandler = kisStockQuoteWebSocketHandler;
+        this.kisWebSocketDispatcher = kisWebSocketDispatcher;
     }
     
     /**
      * 한국투자증권 웹소켓 세션 연결 메서드
+     *
+     * <p> 세션 연결 시, 한국투자증권 웹소켓 공통 응답 처리 및 위임 핸들러 {@link KisWebSocketDispatcher}를 핸들러로 설정한다.
      *
      * @return  한국투자증권 웹소켓과 연결된 세션
      */
     public WebSocketSession connect() {
         try {
             WebSocketSession session = webSocketClient
-                    .execute(kisStockQuoteWebSocketHandler, webSocketDomain).join();
+                    .execute(kisWebSocketDispatcher, webSocketDomain).join();
             
             return session;
         } catch (Exception e) {
-            log.error("[Error] Failed to connect to KIS WebSocket - {}", e.getMessage());
-            return null;
+            throw new KisApiException("한국투자증권 웹소켓 세션 연결에 실패하였습니다.", e);
         }
     }
 }

--- a/src/main/java/muzusi/infrastructure/kis/websocket/KisWebSocketMessageParser.java
+++ b/src/main/java/muzusi/infrastructure/kis/websocket/KisWebSocketMessageParser.java
@@ -1,0 +1,49 @@
+package muzusi.infrastructure.kis.websocket;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import muzusi.infrastructure.kis.websocket.dto.KisWebSocketMetaResponseDto;
+import muzusi.infrastructure.kis.websocket.dto.KisWebSocketResponseDto;
+import org.springframework.stereotype.Component;
+
+import java.util.StringTokenizer;
+
+@Component
+@RequiredArgsConstructor
+public class KisWebSocketMessageParser {
+    private final ObjectMapper objectMapper;
+
+    private static final String PAYLOAD_DELIMITER = "|";
+    private static final String IS_ENCODED_FLAG = "1";
+
+    /**
+     * 한국투자증권 웹소켓 실시간 응답 페이로드를 파싱하는 메서드
+     *
+     * <p> 실시간 응답은 {@link #PAYLOAD_DELIMITER} 로 구분된 "암호화 여부 | TR_ID | 데이터 건수 | 데이터" 형식으로 전달된다.
+     *
+     * @param payload   한국투자증권 웹소켓 실시간 응답 페이로드
+     * @return          파싱된 실시간 응답 DTO
+     */
+    public KisWebSocketResponseDto parse(String payload) {
+        StringTokenizer st = new StringTokenizer(payload, PAYLOAD_DELIMITER);
+
+        return KisWebSocketResponseDto.builder()
+                .isEncoded(IS_ENCODED_FLAG.equals(st.nextToken()))
+                .trId(st.nextToken())
+                .dataCount(Integer.parseInt(st.nextToken()))
+                .data(st.nextToken())
+                .build();
+    }
+
+    /**
+     * 한국투자증권 웹소켓 메타 메시지(JSON) 페이로드를 파싱하는 메서드
+     *
+     * @param payload   한국투자증권 웹소켓 메타 메시지 페이로드
+     * @return          파싱된 메타 메시지 응답 DTO
+     * @throws JsonProcessingException JSON 역직렬화에 실패한 경우
+     */
+    public KisWebSocketMetaResponseDto parseMeta(String payload) throws JsonProcessingException {
+        return objectMapper.readValue(payload, KisWebSocketMetaResponseDto.class);
+    }
+}

--- a/src/main/java/muzusi/infrastructure/kis/websocket/dto/KisWebSocketMetaResponseDto.java
+++ b/src/main/java/muzusi/infrastructure/kis/websocket/dto/KisWebSocketMetaResponseDto.java
@@ -1,0 +1,36 @@
+package muzusi.infrastructure.kis.websocket.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KisWebSocketMetaResponseDto(
+        Header header,
+        Body body
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Header(
+            @JsonProperty("tr_id") String trId
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Body(
+            @JsonProperty("rt_cd") String rtCd,
+            @JsonProperty("msg_cd") String msgCd,
+            String msg1,
+            Output output
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Output(
+            String iv,
+            String key
+    ) {
+    }
+
+    public boolean isSuccess() {
+        return body != null && "0".equals(body.rtCd());
+    }
+}

--- a/src/main/java/muzusi/infrastructure/kis/websocket/dto/KisWebSocketResponseDto.java
+++ b/src/main/java/muzusi/infrastructure/kis/websocket/dto/KisWebSocketResponseDto.java
@@ -1,0 +1,12 @@
+package muzusi.infrastructure.kis.websocket.dto;
+
+import lombok.Builder;
+
+@Builder
+public record KisWebSocketResponseDto(
+        boolean isEncoded,
+        String trId,
+        int dataCount,
+        String data
+) {
+}

--- a/src/main/java/muzusi/infrastructure/kis/websocket/handler/KisWebSocketDispatcher.java
+++ b/src/main/java/muzusi/infrastructure/kis/websocket/handler/KisWebSocketDispatcher.java
@@ -1,0 +1,151 @@
+package muzusi.infrastructure.kis.websocket.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import muzusi.infrastructure.kis.websocket.KisWebSocketMessageParser;
+import muzusi.infrastructure.kis.websocket.dto.KisWebSocketMetaResponseDto;
+import muzusi.infrastructure.kis.websocket.dto.KisWebSocketResponseDto;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class KisWebSocketDispatcher extends TextWebSocketHandler {
+    private final KisWebSocketMessageParser kisWebSocketMessageParser;
+    private final Map<String, KisWebSocketHandler> kisWebSocketHandlerMap;
+    
+    private static final String PING_PONG_TR_ID = "PINGPONG";
+    
+    /**
+     * 스프링 빈으로 등록된 모든 {@link KisWebSocketHandler} 구현체를 TR_ID 기준으로 매핑하는 생성자
+     *
+     * @param kisWebSocketMessageParser    한국투자증권 웹소켓 메시지 파서
+     * @param kisWebSocketHandlers         스프링 빈으로 등록된 {@link KisWebSocketHandler} 구현체 목록
+     */
+    public KisWebSocketDispatcher(KisWebSocketMessageParser kisWebSocketMessageParser, List<KisWebSocketHandler> kisWebSocketHandlers) {
+        this.kisWebSocketMessageParser = kisWebSocketMessageParser;
+        this.kisWebSocketHandlerMap = new HashMap<>();
+        
+        for (KisWebSocketHandler kisWebSocketHandler : kisWebSocketHandlers) {
+            kisWebSocketHandlerMap.put(kisWebSocketHandler.getTrId(), kisWebSocketHandler);
+        }
+    }
+    
+    /**
+     * 한국투자증권 웹소켓 서버와의 연결이 수립된 직후 호출되는 메서드
+     *
+     * @param session   한국투자증권 웹소켓 서버와 연결된 세션
+     */
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        log.info("KIS Websocket connected - session id: {}", session.getId());
+        super.afterConnectionEstablished(session);
+    }
+    
+    /**
+     * 한국투자증권 웹소켓 세션을 통해 수신되는 텍스트 메시지({@code TextMessage})를 처리하는 메서드
+     *
+     * <p> 메타 메시지는 메시지 정보에 맞게 처리 후, 해당 메서드를 종료한다.
+     *
+     * <p> 실시간 응답은 응답의 TR_ID({@link KisWebSocketResponseDto#trId})를 통해 해당 응답을 처리 가능한 핸들러에게 처리를 위임한다.
+     *
+     * @param session
+     * @param message
+     * @throws Exception
+     */
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        String payload = message.getPayload();
+        
+        if (isMetaMessage(payload)) {
+            handleMetaMessage(session, payload);
+            return;
+        }
+        
+        KisWebSocketResponseDto response = kisWebSocketMessageParser.parse(payload);
+        KisWebSocketHandler kisWebSocketHandler = kisWebSocketHandlerMap.get(response.trId());
+        
+        if (kisWebSocketHandler == null) {
+            log.error("[Error] No KIS websocket handler registered for TR_ID: {}", response.trId());
+            return;
+        }
+        
+        kisWebSocketHandler.handle(response);
+    }
+    
+    /**
+     * 한국투자증권 웹소켓 세션에서 전송 계층 오류가 발생했을 때 호출되는 메서드
+     *
+     * @param session   한국투자증권 웹소켓 서버와 연결된 세션
+     * @param exception 발생한 예외
+     */
+    @Override
+    public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
+        log.error("[Error] KIS Websocket transport error - session id: {}, message: {}", session.getId(), exception.getMessage());
+        super.handleTransportError(session, exception);
+    }
+
+    /**
+     * 한국투자증권 웹소켓 서버와의 연결이 종료된 직후 호출되는 메서드
+     *
+     * @param session   한국투자증권 웹소켓 서버와 연결된 세션
+     * @param status    연결 종료 상태
+     */
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        log.info("KIS Websocket disconnected - session id: {}", session.getId());
+        super.afterConnectionClosed(session, status);
+    }
+    
+    /**
+     * 한국투자증권 메타 메시지를 처리하는 메서드
+     *
+     * @param session       한국투자증권 웹소켓 서버와 연결된 세션
+     * @param payload       페이로드
+     */
+    private void handleMetaMessage(WebSocketSession session, String payload) throws IOException {
+        KisWebSocketMetaResponseDto metaMessage = kisWebSocketMessageParser.parseMeta(payload);
+        
+        if (isPingPong(metaMessage)) {
+            session.sendMessage(new TextMessage(payload));
+            return;
+        }
+        
+        if (metaMessage.body() != null && metaMessage.body().msg1() != null) {
+            log.info("[KIS Websocket] tr id: {} / msg: {}", metaMessage.header().trId(), metaMessage.body().msg1());
+        }
+    }
+    
+    /**
+     * 한국투자증권 메타 메시지 응답의 핑퐁 메시지 여부를 반환하는 메서드
+     *
+     * <p> 한국투자증권 웹소켓은 세션 내 데이터 교환이 없을 경우, 세션 유지를 위해 주기적으로 PingPong 메시지를 보낸다.
+     * <p> PingPong 메시지는 응답 메시지 헤더의 TR_ID({@code header.tr_id}) 부분에 {@link #PING_PONG_TR_ID} 값을 포함한다.
+     *
+     * @param response  한국투자증권 메타 메시지 응답 DTO
+     * @return          핑퐁 메시지 여부
+     */
+    private boolean isPingPong(KisWebSocketMetaResponseDto response) {
+        return response.header().trId().equals(PING_PONG_TR_ID);
+    }
+    
+    /**
+     * 한국투자증권 웹소켓 요청에 대한 메타 메시지 여부를 반환하는 메서드
+     *
+     * <p> 한국투자증권 웹소켓은 정상 등록 여부(메타 정보), 핑퐁 메시지를 JSON 형태로 전달한다.
+     * <p> 따라서, 이를 판별하기 위해 중괄호를 통해 메타 메시지 여부를 식별한다.
+     *
+     * @param payload   페이로드
+     * @return          메타 메시지 여부
+     */
+    private boolean isMetaMessage(String payload) {
+        return payload.startsWith("{") || payload.endsWith("}");
+    }
+}

--- a/src/main/java/muzusi/infrastructure/kis/websocket/handler/KisWebSocketHandler.java
+++ b/src/main/java/muzusi/infrastructure/kis/websocket/handler/KisWebSocketHandler.java
@@ -1,0 +1,8 @@
+package muzusi.infrastructure.kis.websocket.handler;
+
+import muzusi.infrastructure.kis.websocket.dto.KisWebSocketResponseDto;
+
+public interface KisWebSocketHandler {
+    String getTrId();
+    void handle(KisWebSocketResponseDto response);
+}

--- a/src/main/java/muzusi/infrastructure/stockquote/adapter/kis/KisStockQuoteAdapter.java
+++ b/src/main/java/muzusi/infrastructure/stockquote/adapter/kis/KisStockQuoteAdapter.java
@@ -35,9 +35,13 @@ public class KisStockQuoteAdapter implements StockQuotePort {
         List<String> connectedSessionIds = new ArrayList<>();
         
         for (String webSocketKey : webSocketKeys) {
-            WebSocketSession session = kisWebSocketConnector.connect();
-            String connectedSessionId = kisWebSocketSessionStore.save(session, webSocketKey);
-            connectedSessionIds.add(connectedSessionId);
+            try {
+                WebSocketSession session = kisWebSocketConnector.connect();
+                String connectedSessionId = kisWebSocketSessionStore.save(session, webSocketKey);
+                connectedSessionIds.add(connectedSessionId);
+            } catch (Exception e) {
+                log.error("[Error] Failed to connect to KIS Websocket - {}", e.getMessage(), e);
+            }
         }
         
         return connectedSessionIds;

--- a/src/main/java/muzusi/infrastructure/stockquote/websocket/kis/KisStockQuoteWebSocketHandler.java
+++ b/src/main/java/muzusi/infrastructure/stockquote/websocket/kis/KisStockQuoteWebSocketHandler.java
@@ -1,15 +1,14 @@
 package muzusi.infrastructure.stockquote.websocket.kis;
 
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import muzusi.application.trade.dto.TradeNotificationDto;
 import muzusi.application.websocket.service.TradeNotificationPublisher;
 import muzusi.domain.trade.type.TradeType;
+import muzusi.infrastructure.kis.websocket.dto.KisWebSocketResponseDto;
+import muzusi.infrastructure.kis.websocket.handler.KisWebSocketHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.socket.CloseStatus;
-import org.springframework.web.socket.TextMessage;
-import org.springframework.web.socket.WebSocketSession;
-import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,134 +16,280 @@ import java.util.List;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class KisStockQuoteWebSocketHandler extends TextWebSocketHandler {
+public class KisStockQuoteWebSocketHandler implements KisWebSocketHandler {
     private final TradeNotificationPublisher tradeNotificationPublisher;
+
+    private static final String TR_ID = "H0STCNT0";
+    private static final int FIELD_COUNT = 46;
     
     /**
-     * 웹소켓 세션 연결 후 실행 메서드
+     * 해당 핸들러가 처리하는 웹소켓 항목의 TR_ID를 반환하는 메서드
      *
-     * @param session       한국투자증권 웹소켓과 연결된 세션
-     * @throws Exception    웹소켓 세션 연결 시 발생 예외
+     * @return  실시간 체결가 조회 TR_ID({@value #TR_ID})
      */
     @Override
-    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
-        log.info("KIS Websocket session connected: {}", session.getId());
-        super.afterConnectionEstablished(session);
+    public String getTrId() {
+        return TR_ID;
     }
-    
+
     /**
-     * 웹소켓 세션 종료 후 실행 메서드
+     * 한국투자증권 실시간 체결가 응답을 파싱해 알림을 발행하는 메서드
      *
-     * @param session       한국투자증권 웹소켓과 연결되었던 세션
-     * @param status        웹소켓 세션 연결 종료 상태
-     * @throws Exception    웹소켓 세션 연결 종료 시 발생 예외
+     * <p> 응답 데이터 파싱 또는 변환 중 예외가 발생하면 알림 발행 없이 로그만 남기고 종료한다.
+     * <p> 체결 구분({@link Response#parseTradeType()})을 판별할 수 없는 데이터는 알림 대상에서 제외한다.
+     *
+     * @param response  한국투자증권 웹소켓 실시간 응답 DTO
      */
     @Override
-    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
-        log.info("KIS Websocket session closed: {}", session.getId());
-        super.afterConnectionClosed(session, status);
-    }
-    
-    /**
-     * 한국투자증권 웹소켓 세션을 통해 전달받은 메시지를 처리하는 메서드
-     *
-     * <p> 구독 주식 종목 실시간 체결가 메시지 수신 시, 해당 종목 구독자에게 메시지 송신
-     *
-     * <p> 세션 연결 유지를 위한 핑퐁(PingPong) 메시지 수신 시, 수신받은 페이로드와 동일한 페이로드를 응답
-     *
-     * @param session       웹소켓 세션
-     * @param message       수신 메시지
-     * @throws Exception    메시지 수신 시 발생 예외
-     */
-    @Override
-    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
-        String payload = message.getPayload();
+    public void handle(KisWebSocketResponseDto response) {
+        int count = response.dataCount();
+        String data = response.data();
+        List<TradeNotificationDto> tradeNotifications = new ArrayList<>();
         
-        if (isPingPong(payload)) {
-            session.sendMessage(new TextMessage(payload));
+        try {
+            List<Response> responses = parseResponse(count, data);
+            tradeNotifications = responses.stream()
+                .map(res -> TradeNotificationDto.builder()
+                        .stockCode(res.MKSC_SHRN_ISCD())
+                        .time(convertTime(res.STCK_CNTG_HOUR()))
+                        .price(res.STCK_PRPR())
+                        .contingentVolume(res.CNTG_VOL())
+                        .accumulatedVolume(res.ACML_VOL())
+                        .tradeType(res.parseTradeType())
+                        .changeRate(res.PRDY_CTRT())
+                        .build())
+                .filter(tradeNotification -> tradeNotification.tradeType() != null)
+                .toList();
+        } catch (Exception e) {
+            log.error("[Error] Failed to parse KIS stock quote response - data: {}, message: {}", response.data(), e.getMessage());
             return;
         }
-        
-        if (isMetaMessage(payload)) {
-            if (isErrorMessage(payload)) {
-                log.error("[Error] Error message from KIS websocket - {}", payload);
-            } else {
-                log.info("[KIS Websocket] - {}", payload);
-            }
-            return;
-        }
-        
-        tradeNotificationPublisher.publishTradeNotification(parsePayloadToNotificationDto(payload));
+
+        tradeNotificationPublisher.publishTradeNotification(tradeNotifications);
     }
-    
+
     /**
-     * 페이로드의 핑퐁 메시지 여부를 확인하는 메서드
+     * HHmmss 형식의 시간 문자열을 HH:mm:ss 형식으로 변환하는 메서드
      *
-     * @param payload   페이로드
-     * @return          페이로드의 핑퐁 메시지 여부
-     */
-    private boolean isPingPong(String payload) {
-        return payload.contains("PINGPONG");
-    }
-    
-    /**
-     * 페이로드의 메타 메시지 여부를 확인하는 메서드
-     *
-     * @param payload   페이로드
-     * @return          페이로드의 메타 메시지 여부
-     */
-    private boolean isMetaMessage(String payload) {
-        return payload != null && !payload.isBlank() && payload.startsWith("{");
-    }
-    
-    /**
-     * 페이로드의 에러 메시지 여부를 확인하는 메서드
-     *
-     * <p> 웹소켓 응답 메타 메시지의 반환 코드(rt_cd)가 0을 제외한 나머지 경우는 모두 에러 응답
-     *
-     * @param payload   페이로드
-     * @return          페이로드의 에러 메시지 여부
-     */
-    private boolean isErrorMessage(String payload) {
-        return !payload.contains("\"rt_cd\":\"0\"");
-    }
-    
-    /**
-     * 페이로드를 해당 주식 종목 구독자에게 전달하기 위한 객체({@link TradeNotificationDto})로 변환하는 메서드
-     *
-     * @param payload   페이로드
-     * @return          {@link TradeNotificationDto} 객체 리스트
-     */
-    private List<TradeNotificationDto> parsePayloadToNotificationDto(String payload) {
-        List<TradeNotificationDto> result = new ArrayList<>();
-        String[] parts = payload.split("\\^");
-        String[] metas = parts[0].split("\\|");
-        int tradeCount = Integer.parseInt(metas[2]);
-        String stockCode = metas[3];
-        
-        for (int idx = 0, i = 0; i < tradeCount; i++) {
-            result.add(TradeNotificationDto.builder()
-                    .stockCode(stockCode)
-                    .time(convertTime(parts[idx + 1]))
-                    .price(Long.valueOf(parts[idx + 2]))
-                    .stockCount(Long.valueOf(parts[idx + 12]))
-                    .volume(Long.valueOf(parts[idx + 13]))
-                    .tradeType((parts[idx + 21].equals("1")) ? TradeType.BUY : TradeType.SELL)
-                    .changeRate(Double.valueOf(parts[idx + 5]))
-                    .build());
-            idx += 46;
-        }
-        
-        return result;
-    }
-    
-    /**
-     * 페이로드에서 전달된 시각을 양식에 맞게 변환하는 메서드
-     *
-     * @param time  페이로드에 전달된 시각
-     * @return      양식에 맞게 변환된 시각
+     * @param time  HHmmss 형식의 시간 문자열
+     * @return      HH:mm:ss 형식으로 변환된 시간 문자열
      */
     private String convertTime(String time) {
         return time.substring(0, 2) + ":" + time.substring(2, 4) + ":" + time.substring(4);
+    }
+
+    /**
+     * 실시간 체결가 응답 데이터({@code data})를 {@link Response} 목록으로 파싱하는 메서드
+     *
+     * <p> 데이터는 {@code ^} 로 구분된 {@value #FIELD_COUNT}개 필드가 {@code count}건 만큼 반복되는 형식이다.
+     *
+     * @param count 응답에 포함된 데이터 건수
+     * @param data  {@code ^} 로 구분된 실시간 체결가 데이터
+     * @return      파싱된 {@link Response} 목록
+     */
+    private List<Response> parseResponse(int count, String data) {
+        String[] items = data.split("\\^", -1);
+        List<Response> responses = new ArrayList<>(count);
+
+        for (int i = 0; i < count; i++) {
+            int offset = i * FIELD_COUNT;
+
+            responses.add(Response.builder()
+                    .MKSC_SHRN_ISCD(items[offset])
+                    .STCK_CNTG_HOUR(items[offset + 1])
+                    .STCK_PRPR(parseLong(items[offset + 2]))
+                    .PRDY_VRSS_SIGN(items[offset + 3])
+                    .PRDY_VRSS(parseInteger(items[offset + 4]))
+                    .PRDY_CTRT(parseDouble(items[offset + 5]))
+                    .WGHN_AVRG_STCK_PRC(parseDouble(items[offset + 6]))
+                    .STCK_OPRC(parseLong(items[offset + 7]))
+                    .STCK_HGPR(parseLong(items[offset + 8]))
+                    .STCK_LWPR(parseLong(items[offset + 9]))
+                    .ASKP1(parseLong(items[offset + 10]))
+                    .BIDP1(parseLong(items[offset + 11]))
+                    .CNTG_VOL(parseLong(items[offset + 12]))
+                    .ACML_VOL(parseLong(items[offset + 13]))
+                    .ACML_TR_PBMN(parseLong(items[offset + 14]))
+                    .SELN_CNTG_CSNU(parseInteger(items[offset + 15]))
+                    .SHNU_CNTG_CSNU(parseInteger(items[offset + 16]))
+                    .NTBY_CNTG_CSNU(parseInteger(items[offset + 17]))
+                    .CTTR(parseDouble(items[offset + 18]))
+                    .SELN_CNTG_SMTN(parseInteger(items[offset + 19]))
+                    .SHNU_CNTG_SMTN(parseInteger(items[offset + 20]))
+                    .CCLD_DVSN(items[offset + 21])
+                    .SHNU_RATE(parseDouble(items[offset + 22]))
+                    .PRDY_VOL_VRSS_ACML_VOL_RATE(parseDouble(items[offset + 23]))
+                    .OPRC_HOUR(items[offset + 24])
+                    .OPRC_VRSS_PRPR_SIGN(items[offset + 25])
+                    .OPRC_VRSS_PRPR(parseInteger(items[offset + 26]))
+                    .HGPR_HOUR(items[offset + 27])
+                    .HGPR_VRSS_PRPR_SIGN(items[offset + 28])
+                    .HGPR_VRSS_PRPR(parseInteger(items[offset + 29]))
+                    .LWPR_HOUR(items[offset + 30])
+                    .LWPR_VRSS_PRPR_SIGN(items[offset + 31])
+                    .LWPR_VRSS_PRPR(parseInteger(items[offset + 32]))
+                    .BSOP_DATE(items[offset + 33])
+                    .NEW_MKOP_CLS_CODE(items[offset + 34])
+                    .TRHT_YN(items[offset + 35])
+                    .ASKP_RSQN1(parseLong(items[offset + 36]))
+                    .BIDP_RSQN1(parseLong(items[offset + 37]))
+                    .TOTAL_ASKP_RSQN(parseLong(items[offset + 38]))
+                    .TOTAL_BIDP_RSQN(parseLong(items[offset + 39]))
+                    .VOL_TNRT(parseDouble(items[offset + 40]))
+                    .PRDY_SMNS_HOUR_ACML_VOL(parseLong(items[offset + 41]))
+                    .PRDY_SMNS_HOUR_ACML_VOL_RATE(parseDouble(items[offset + 42]))
+                    .HOUR_CLS_CODE(items[offset + 43])
+                    .MRKT_TRTM_CLS_CODE(items[offset + 44])
+                    .VI_STND_PRC(parseLong(items[offset + 45]))
+                    .build());
+        }
+
+        return responses;
+    }
+
+    /**
+     * 문자열을 {@link Long}으로 변환하는 메서드
+     *
+     * @param value 변환할 문자열
+     * @return      변환된 {@link Long} 값, {@code value}가 {@code null}이거나 공백이면 {@code null}
+     */
+    private Long parseLong(String value) {
+        return (value == null || value.isBlank()) ? null : Long.valueOf(value);
+    }
+
+    /**
+     * 문자열을 {@link Integer}로 변환하는 메서드
+     *
+     * @param value 변환할 문자열
+     * @return      변환된 {@link Integer} 값, {@code value}가 {@code null}이거나 공백이면 {@code null}
+     */
+    private Integer parseInteger(String value) {
+        return (value == null || value.isBlank()) ? null : Integer.valueOf(value);
+    }
+
+    /**
+     * 문자열을 {@link Double}로 변환하는 메서드
+     *
+     * @param value 변환할 문자열
+     * @return      변환된 {@link Double} 값, {@code value}가 {@code null}이거나 공백이면 {@code null}
+     */
+    private Double parseDouble(String value) {
+        return (value == null || value.isBlank()) ? null : Double.valueOf(value);
+    }
+    
+    /**
+     * 한국투자증권 실시간 체결가 웹소켓 응답 필드
+     *
+     * @param MKSC_SHRN_ISCD                    유가증권 단축 종목코드
+     * @param STCK_CNTG_HOUR                    주식 체결 시간
+     * @param STCK_PRPR                         주식 현재가
+     * @param PRDY_VRSS_SIGN                    전일 대비 부호 (1: 상한, 2: 상승, 3: 보합, 4: 하한, 5: 하락)
+     * @param PRDY_VRSS                         전일 대비
+     * @param PRDY_CTRT                         전일 대비율
+     * @param WGHN_AVRG_STCK_PRC                가중평균 주식 가격
+     * @param STCK_OPRC                         주식 시가
+     * @param STCK_HGPR                         주식 최고가
+     * @param STCK_LWPR                         주식 최저가
+     * @param ASKP1                             매도호가1
+     * @param BIDP1                             매수호가1
+     * @param CNTG_VOL                          체결 거래량
+     * @param ACML_VOL                          누적 거래량
+     * @param ACML_TR_PBMN                      누적 거래대금
+     * @param SELN_CNTG_CSNU                    매도 체결 건수
+     * @param SHNU_CNTG_CSNU                    매수 체결 건수
+     * @param NTBY_CNTG_CSNU                    순매수 체결 건수
+     * @param CTTR                              체결 강도
+     * @param SELN_CNTG_SMTN                    총 매도 수량
+     * @param SHNU_CNTG_SMTN                    총 매수 수량
+     * @param CCLD_DVSN                         체결 구분 (1: 매수(+), 3: 장전, 5: 매도(-))
+     * @param SHNU_RATE                         매수 비율
+     * @param PRDY_VOL_VRSS_ACML_VOL_RATE       전일 거래량 대비 누적 거래량 비율
+     * @param OPRC_HOUR                         시가 시간
+     * @param OPRC_VRSS_PRPR_SIGN               시가대비 구분 (1: 상한, 2: 상승, 3: 보합, 4: 하한, 5: 하락)
+     * @param OPRC_VRSS_PRPR                    시가 대비
+     * @param HGPR_HOUR                         최고가 시간
+     * @param HGPR_VRSS_PRPR_SIGN               고가 대비 구분 (1: 상한, 2: 상승, 3: 보합, 4: 하한, 5: 하락)
+     * @param HGPR_VRSS_PRPR                    고가 대비
+     * @param LWPR_HOUR                         최저가 시간
+     * @param LWPR_VRSS_PRPR_SIGN               저가 대비 구분 (1: 상한, 2: 상승, 3: 보합, 4: 하한, 5: 하락)
+     * @param LWPR_VRSS_PRPR                    저가 대비
+     * @param BSOP_DATE                         영업 일자
+     * @param NEW_MKOP_CLS_CODE                 신 장 운영 구분 코드
+     *                                          <p> - 첫번째 비트 (1: 장 개시 전, 2: 장 중, 3: 장 종료 후, 4: 시간외 단일가, 7: 일반 Buy-in, 8: 당일 Buy-in)
+     *                                          <p> - 두번째 비트 (0: 보통, 1: 종가, 2: 대량, 3: 바스켓: 7: 정리매매: 8: Buy-in)
+     * @param TRHT_YN                           거래 정지 여부 (Y: 정지, N: 정상거래)
+     * @param ASKP_RSQN1                        매도호가 잔량1
+     * @param BIDP_RSQN1                        매수호가 잔량1
+     * @param TOTAL_ASKP_RSQN                   총 매도호가 잔량
+     * @param TOTAL_BIDP_RSQN                   총 매수호가 잔량
+     * @param VOL_TNRT                          거래량 회전율
+     * @param PRDY_SMNS_HOUR_ACML_VOL           전일 동시간 누적 거래량
+     * @param PRDY_SMNS_HOUR_ACML_VOL_RATE      전일 동시간 누적 거래량 비율
+     * @param HOUR_CLS_CODE                     시간 구분 코드 (0: 장 중, A: 장후 예상: B: 장전 예상, C: 9시 이후의 예상가/VI 발동, D: 시간외 단일가 예상)
+     * @param MRKT_TRTM_CLS_CODE                임의 종료 구분 코드
+     * @param VI_STND_PRC                       정적VI발동기준가
+     */
+    @Builder
+    private record Response(
+            String MKSC_SHRN_ISCD,
+            String STCK_CNTG_HOUR,
+            Long STCK_PRPR,
+            String PRDY_VRSS_SIGN,
+            Integer PRDY_VRSS,
+            Double PRDY_CTRT,
+            Double WGHN_AVRG_STCK_PRC,
+            Long STCK_OPRC,
+            Long STCK_HGPR,
+            Long STCK_LWPR,
+            Long ASKP1,
+            Long BIDP1,
+            Long CNTG_VOL,
+            Long ACML_VOL,
+            Long ACML_TR_PBMN,
+            Integer SELN_CNTG_CSNU,
+            Integer SHNU_CNTG_CSNU,
+            Integer NTBY_CNTG_CSNU,
+            Double CTTR,
+            Integer SELN_CNTG_SMTN,
+            Integer SHNU_CNTG_SMTN,
+            String CCLD_DVSN,
+            Double SHNU_RATE,
+            Double PRDY_VOL_VRSS_ACML_VOL_RATE,
+            String OPRC_HOUR,
+            String OPRC_VRSS_PRPR_SIGN,
+            Integer OPRC_VRSS_PRPR,
+            String HGPR_HOUR,
+            String HGPR_VRSS_PRPR_SIGN,
+            Integer HGPR_VRSS_PRPR,
+            String LWPR_HOUR,
+            String LWPR_VRSS_PRPR_SIGN,
+            Integer LWPR_VRSS_PRPR,
+            String BSOP_DATE,
+            String NEW_MKOP_CLS_CODE,
+            String TRHT_YN,
+            Long ASKP_RSQN1,
+            Long BIDP_RSQN1,
+            Long TOTAL_ASKP_RSQN,
+            Long TOTAL_BIDP_RSQN,
+            Double VOL_TNRT,
+            Long PRDY_SMNS_HOUR_ACML_VOL,
+            Double PRDY_SMNS_HOUR_ACML_VOL_RATE,
+            String HOUR_CLS_CODE,
+            String MRKT_TRTM_CLS_CODE,
+            Long VI_STND_PRC
+    ) {
+        
+        /**
+         * 체결 구분({@link #CCLD_DVSN}) 값을 {@link TradeType}으로 변환하는 메서드
+         *
+         * <p> {@code CCLD_DVSN}이 매수/매도(1, 5)가 아닌 값(예: 장전 3)인 경우 판별할 수 없으므로 {@code null}을 반환한다.
+         *
+         * @return  변환된 {@link TradeType}, 매수/매도로 판별할 수 없으면 {@code null}
+         */
+        public TradeType parseTradeType() {
+            if (CCLD_DVSN.equals("1")) return TradeType.BUY;
+            if (CCLD_DVSN.equals("5")) return TradeType.SELL;
+            return null;
+        }
     }
 }

--- a/src/test/java/muzusi/infrastructure/kis/websocket/KisWebSocketConnectorTest.java
+++ b/src/test/java/muzusi/infrastructure/kis/websocket/KisWebSocketConnectorTest.java
@@ -1,0 +1,99 @@
+package muzusi.infrastructure.kis.websocket;
+
+import muzusi.infrastructure.kis.exception.KisApiException;
+import muzusi.infrastructure.kis.websocket.handler.KisWebSocketDispatcher;
+import muzusi.infrastructure.properties.KisProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.client.WebSocketClient;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class KisWebSocketConnectorTest {
+
+    private static final String WEBSOCKET_DOMAIN = "wss://kis.example.com";
+
+    @Mock
+    private KisProperties kisProperties;
+
+    @Mock
+    private KisWebSocketDispatcher kisWebSocketDispatcher;
+
+    @Mock
+    private WebSocketClient webSocketClient;
+
+    private KisWebSocketConnector kisWebSocketConnector;
+
+    @BeforeEach
+    void setUp() {
+        when(kisProperties.getWebSocketDomain()).thenReturn(WEBSOCKET_DOMAIN);
+        kisWebSocketConnector = new KisWebSocketConnector(kisProperties, kisWebSocketDispatcher);
+
+        // webSocketClient는 생성자로 주입되지 않고 필드에서 직접 생성되므로,
+        // 테스트에서 목(mock)으로 교체하기 위해 리플렉션을 사용한다.
+        ReflectionTestUtils.setField(kisWebSocketConnector, "webSocketClient", webSocketClient);
+    }
+
+    @Nested
+    @DisplayName("연결")
+    class Connect {
+        @Test
+        @DisplayName("웹소켓 연결에 성공하면 연결된 세션을 반환한다")
+        void successReturnConnectedSession() {
+            // given
+            WebSocketSession session = org.mockito.Mockito.mock(WebSocketSession.class);
+            when(webSocketClient.execute(kisWebSocketDispatcher, WEBSOCKET_DOMAIN))
+                    .thenReturn(CompletableFuture.completedFuture(session));
+
+            // when
+            WebSocketSession connectedSession = kisWebSocketConnector.connect();
+
+            // then
+            assertThat(connectedSession).isEqualTo(session);
+            verify(webSocketClient).execute(kisWebSocketDispatcher, WEBSOCKET_DOMAIN);
+        }
+
+        @Test
+        @DisplayName("웹소켓 클라이언트가 연결 시도 중 예외를 던지면 KisApiException을 던진다")
+        void throwKisApiExceptionWhenExecuteThrows() {
+            // given
+            when(webSocketClient.execute(any(), anyString()))
+                    .thenThrow(new IllegalStateException("invalid uri"));
+
+            // when & then
+            assertThatThrownBy(() -> kisWebSocketConnector.connect())
+                    .isInstanceOf(KisApiException.class)
+                    .hasMessage("한국투자증권 웹소켓 세션 연결에 실패하였습니다.")
+                    .hasCauseInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        @DisplayName("웹소켓 연결이 비동기적으로 실패하면 KisApiException을 던진다")
+        void throwKisApiExceptionWhenConnectionFailsAsynchronously() {
+            // given
+            CompletableFuture<WebSocketSession> future = new CompletableFuture<>();
+            future.completeExceptionally(new RuntimeException("connection refused"));
+            when(webSocketClient.execute(any(), anyString())).thenReturn(future);
+
+            // when & then
+            assertThatThrownBy(() -> kisWebSocketConnector.connect())
+                    .isInstanceOf(KisApiException.class)
+                    .hasMessage("한국투자증권 웹소켓 세션 연결에 실패하였습니다.");
+        }
+    }
+}

--- a/src/test/java/muzusi/infrastructure/kis/websocket/handler/KisWebSocketDispatcherTest.java
+++ b/src/test/java/muzusi/infrastructure/kis/websocket/handler/KisWebSocketDispatcherTest.java
@@ -1,0 +1,198 @@
+package muzusi.infrastructure.kis.websocket.handler;
+
+import muzusi.infrastructure.kis.websocket.KisWebSocketMessageParser;
+import muzusi.infrastructure.kis.websocket.dto.KisWebSocketMetaResponseDto;
+import muzusi.infrastructure.kis.websocket.dto.KisWebSocketResponseDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class KisWebSocketDispatcherTest {
+
+    private static final String TR_ID = "H0STCNT0";
+    private static final String PING_PONG_TR_ID = "PINGPONG";
+
+    @Mock
+    private KisWebSocketMessageParser kisWebSocketMessageParser;
+
+    @Mock
+    private KisWebSocketHandler kisWebSocketHandler;
+
+    @Mock
+    private WebSocketSession session;
+
+    private KisWebSocketDispatcher dispatcher;
+
+    @BeforeEach
+    void setUp() {
+        when(kisWebSocketHandler.getTrId()).thenReturn(TR_ID);
+        dispatcher = new KisWebSocketDispatcher(kisWebSocketMessageParser, List.of(kisWebSocketHandler));
+    }
+
+    @Nested
+    @DisplayName("연결 수립/종료")
+    class ConnectionLifecycle {
+        @Test
+        @DisplayName("연결이 수립되면 예외 없이 처리된다")
+        void successAfterConnectionEstablished() {
+            // given
+            when(session.getId()).thenReturn("sessionId1");
+
+            // when & then
+            assertThatCode(() -> dispatcher.afterConnectionEstablished(session))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("연결이 종료되면 예외 없이 처리된다")
+        void successAfterConnectionClosed() {
+            // given
+            when(session.getId()).thenReturn("sessionId1");
+
+            // when & then
+            assertThatCode(() -> dispatcher.afterConnectionClosed(session, org.springframework.web.socket.CloseStatus.NORMAL))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("전송 계층 오류가 발생하면 예외 없이 처리된다")
+        void successHandleTransportError() {
+            // given
+            when(session.getId()).thenReturn("sessionId1");
+
+            // when & then
+            assertThatCode(() -> dispatcher.handleTransportError(session, new IllegalStateException("transport error")))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("메타 메시지 처리")
+    class MetaMessage {
+        @Test
+        @DisplayName("PingPong 메시지를 수신하면 동일한 페이로드를 그대로 응답한다")
+        void successEchoPingPongMessage() throws Exception {
+            // given
+            String payload = "{\"header\":{\"tr_id\":\"PINGPONG\"}}";
+            TextMessage message = new TextMessage(payload);
+            KisWebSocketMetaResponseDto metaResponse = new KisWebSocketMetaResponseDto(
+                    new KisWebSocketMetaResponseDto.Header(PING_PONG_TR_ID), null
+            );
+            when(kisWebSocketMessageParser.parseMeta(payload)).thenReturn(metaResponse);
+
+            // when
+            dispatcher.handleTextMessage(session, message);
+
+            // then
+            ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
+            verify(session).sendMessage(captor.capture());
+            assertThat(captor.getValue().getPayload()).isEqualTo(payload);
+
+            verify(kisWebSocketMessageParser, never()).parse(anyString());
+            verify(kisWebSocketHandler, never()).handle(any());
+        }
+
+        @Test
+        @DisplayName("PingPong이 아닌 메타 메시지(구독 응답 등)를 수신하면 응답하지 않고 실시간 데이터로도 처리하지 않는다")
+        void successHandleNonPingPongMetaMessage() throws Exception {
+            // given
+            String payload = "{\"header\":{\"tr_id\":\"H0STCNT0\"},\"body\":{\"rt_cd\":\"0\",\"msg1\":\"SUBSCRIBE SUCCESS\"}}";
+            TextMessage message = new TextMessage(payload);
+            KisWebSocketMetaResponseDto metaResponse = new KisWebSocketMetaResponseDto(
+                    new KisWebSocketMetaResponseDto.Header(TR_ID),
+                    new KisWebSocketMetaResponseDto.Body("0", "OPSP0000", "SUBSCRIBE SUCCESS", null)
+            );
+            when(kisWebSocketMessageParser.parseMeta(payload)).thenReturn(metaResponse);
+
+            // when
+            dispatcher.handleTextMessage(session, message);
+
+            // then
+            verify(session, never()).sendMessage(any());
+            verify(kisWebSocketMessageParser, never()).parse(anyString());
+            verify(kisWebSocketHandler, never()).handle(any());
+        }
+
+        @Test
+        @DisplayName("메타 메시지의 body가 없어도 예외 없이 처리된다")
+        void successHandleMetaMessageWithoutBody() throws Exception {
+            // given
+            String payload = "{\"header\":{\"tr_id\":\"H0STCNT0\"}}";
+            TextMessage message = new TextMessage(payload);
+            KisWebSocketMetaResponseDto metaResponse = new KisWebSocketMetaResponseDto(
+                    new KisWebSocketMetaResponseDto.Header(TR_ID), null
+            );
+            when(kisWebSocketMessageParser.parseMeta(payload)).thenReturn(metaResponse);
+
+            // when & then
+            assertThatCode(() -> dispatcher.handleTextMessage(session, message))
+                    .doesNotThrowAnyException();
+
+            verify(session, never()).sendMessage(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("실시간 데이터 메시지 처리")
+    class DataMessage {
+        @Test
+        @DisplayName("TR_ID에 해당하는 핸들러가 등록되어 있으면 해당 핸들러에게 처리를 위임한다")
+        void successDelegateToRegisteredHandler() throws Exception {
+            // given
+            String payload = "1|H0STCNT0|001|005930^091530^70000";
+            TextMessage message = new TextMessage(payload);
+            KisWebSocketResponseDto response = KisWebSocketResponseDto.builder()
+                    .isEncoded(true)
+                    .trId(TR_ID)
+                    .dataCount(1)
+                    .data("005930^091530^70000")
+                    .build();
+            when(kisWebSocketMessageParser.parse(payload)).thenReturn(response);
+
+            // when
+            dispatcher.handleTextMessage(session, message);
+
+            // then
+            verify(kisWebSocketHandler).handle(response);
+        }
+
+        @Test
+        @DisplayName("TR_ID에 해당하는 핸들러가 없으면 처리를 위임하지 않는다")
+        void doNothingWhenHandlerNotRegistered() throws Exception {
+            // given
+            String payload = "1|UNKNOWN|001|005930^091530^70000";
+            TextMessage message = new TextMessage(payload);
+            KisWebSocketResponseDto response = KisWebSocketResponseDto.builder()
+                    .isEncoded(true)
+                    .trId("UNKNOWN")
+                    .dataCount(1)
+                    .data("005930^091530^70000")
+                    .build();
+            when(kisWebSocketMessageParser.parse(payload)).thenReturn(response);
+
+            // when
+            dispatcher.handleTextMessage(session, message);
+
+            // then
+            verify(kisWebSocketHandler, never()).handle(any());
+        }
+    }
+}

--- a/src/test/java/muzusi/infrastructure/stockquote/websocket/kis/KisStockQuoteWebSocketHandlerTest.java
+++ b/src/test/java/muzusi/infrastructure/stockquote/websocket/kis/KisStockQuoteWebSocketHandlerTest.java
@@ -1,0 +1,208 @@
+package muzusi.infrastructure.stockquote.websocket.kis;
+
+import muzusi.application.trade.dto.TradeNotificationDto;
+import muzusi.application.websocket.service.TradeNotificationPublisher;
+import muzusi.domain.trade.type.TradeType;
+import muzusi.infrastructure.kis.websocket.dto.KisWebSocketResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class KisStockQuoteWebSocketHandlerTest {
+
+    private static final String TR_ID = "H0STCNT0";
+    private static final int FIELD_COUNT = 46;
+
+    @Mock
+    private TradeNotificationPublisher tradeNotificationPublisher;
+
+    @InjectMocks
+    private KisStockQuoteWebSocketHandler kisStockQuoteWebSocketHandler;
+
+    @Test
+    @DisplayName("이 핸들러가 처리하는 TR_ID를 반환한다")
+    void successReturnTrId() {
+        // when & then
+        assertThat(kisStockQuoteWebSocketHandler.getTrId()).isEqualTo(TR_ID);
+    }
+
+    @Nested
+    @DisplayName("실시간 체결가 응답 처리")
+    class Handle {
+        @Test
+        @DisplayName("체결 구분이 매수(1)인 데이터를 거래 체결 알림으로 발행한다")
+        void successPublishBuyTradeNotification() {
+            // given
+            String data = buildData(item("005930", "091530", "70000", "1.23", "10", "1000", "1"));
+            KisWebSocketResponseDto response = buildResponse(1, data);
+
+            // when
+            kisStockQuoteWebSocketHandler.handle(response);
+
+            // then
+            List<TradeNotificationDto> published = capturePublished();
+            assertThat(published).hasSize(1);
+            TradeNotificationDto notification = published.get(0);
+            assertThat(notification.stockCode()).isEqualTo("005930");
+            assertThat(notification.time()).isEqualTo("09:15:30");
+            assertThat(notification.price()).isEqualTo(70000L);
+            assertThat(notification.contingentVolume()).isEqualTo(10L);
+            assertThat(notification.accumulatedVolume()).isEqualTo(1000L);
+            assertThat(notification.tradeType()).isEqualTo(TradeType.BUY);
+            assertThat(notification.changeRate()).isEqualTo(1.23);
+        }
+
+        @Test
+        @DisplayName("체결 구분이 매도(5)인 데이터를 거래 체결 알림으로 발행한다")
+        void successPublishSellTradeNotification() {
+            // given
+            String data = buildData(item("000660", "133000", "150000", "-2.5", "5", "500", "5"));
+            KisWebSocketResponseDto response = buildResponse(1, data);
+
+            // when
+            kisStockQuoteWebSocketHandler.handle(response);
+
+            // then
+            List<TradeNotificationDto> published = capturePublished();
+            assertThat(published).hasSize(1);
+            assertThat(published.get(0).tradeType()).isEqualTo(TradeType.SELL);
+        }
+
+        @Test
+        @DisplayName("여러 건의 데이터가 포함되어 있으면 모두 파싱해 순서대로 발행한다")
+        void successPublishMultipleTradeNotifications() {
+            // given
+            String data = buildData(
+                    item("005930", "091530", "70000", "1.23", "10", "1000", "1"),
+                    item("000660", "091531", "150000", "-0.5", "3", "300", "5")
+            );
+            KisWebSocketResponseDto response = buildResponse(2, data);
+
+            // when
+            kisStockQuoteWebSocketHandler.handle(response);
+
+            // then
+            List<TradeNotificationDto> published = capturePublished();
+            assertThat(published).hasSize(2);
+            assertThat(published.get(0).stockCode()).isEqualTo("005930");
+            assertThat(published.get(1).stockCode()).isEqualTo("000660");
+        }
+
+        @Test
+        @DisplayName("체결 구분이 매수/매도로 판별되지 않는 데이터(예: 장전 3)는 발행 대상에서 제외한다")
+        void excludeUnknownTradeTypeFromNotification() {
+            // given
+            String data = buildData(
+                    item("005930", "091530", "70000", "1.23", "10", "1000", "3"),
+                    item("000660", "091531", "150000", "-0.5", "3", "300", "5")
+            );
+            KisWebSocketResponseDto response = buildResponse(2, data);
+
+            // when
+            kisStockQuoteWebSocketHandler.handle(response);
+
+            // then
+            List<TradeNotificationDto> published = capturePublished();
+            assertThat(published).hasSize(1);
+            assertThat(published.get(0).stockCode()).isEqualTo("000660");
+        }
+
+        @Test
+        @DisplayName("모든 데이터의 체결 구분을 판별할 수 없으면 빈 목록을 발행한다")
+        void publishEmptyListWhenAllTradeTypesUnknown() {
+            // given
+            String data = buildData(item("005930", "091530", "70000", "1.23", "10", "1000", "3"));
+            KisWebSocketResponseDto response = buildResponse(1, data);
+
+            // when
+            kisStockQuoteWebSocketHandler.handle(response);
+
+            // then
+            assertThat(capturePublished()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("데이터 건수가 실제 데이터보다 많아 파싱에 실패하면 발행하지 않는다")
+        void doNotPublishWhenDataIsMalformed() {
+            // given: dataCount는 2건이지만 실제 데이터는 1건 분량만 존재
+            String data = buildData(item("005930", "091530", "70000", "1.23", "10", "1000", "1"));
+            KisWebSocketResponseDto response = buildResponse(2, data);
+
+            // when
+            kisStockQuoteWebSocketHandler.handle(response);
+
+            // then
+            verifyNoInteractions(tradeNotificationPublisher);
+        }
+
+        @Test
+        @DisplayName("체결 시간 형식이 올바르지 않아 변환에 실패하면 발행하지 않는다")
+        void doNotPublishWhenTimeFormatIsInvalid() {
+            // given: 체결 시간이 HHmmss(6자리) 형식이 아님
+            String data = buildData(item("005930", "12", "70000", "1.23", "10", "1000", "1"));
+            KisWebSocketResponseDto response = buildResponse(1, data);
+
+            // when
+            kisStockQuoteWebSocketHandler.handle(response);
+
+            // then
+            verifyNoInteractions(tradeNotificationPublisher);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<TradeNotificationDto> capturePublished() {
+        ArgumentCaptor<List<TradeNotificationDto>> captor = ArgumentCaptor.forClass(List.class);
+        verify(tradeNotificationPublisher).publishTradeNotification(captor.capture());
+        return captor.getValue();
+    }
+
+    private KisWebSocketResponseDto buildResponse(int count, String data) {
+        return KisWebSocketResponseDto.builder()
+                .isEncoded(true)
+                .trId(TR_ID)
+                .dataCount(count)
+                .data(data)
+                .build();
+    }
+
+    /**
+     * 실시간 체결가 데이터 한 건({@value #FIELD_COUNT}개 필드)을 생성한다.
+     * 테스트에서 검증하지 않는 필드는 빈 문자열로 채운다.
+     */
+    private String[] item(String stockCode, String time, String price, String changeRate,
+                           String contingentVolume, String accumulatedVolume, String ccldDvsn) {
+        String[] fields = new String[FIELD_COUNT];
+        Arrays.fill(fields, "");
+        fields[0] = stockCode;             // MKSC_SHRN_ISCD
+        fields[1] = time;                  // STCK_CNTG_HOUR
+        fields[2] = price;                 // STCK_PRPR
+        fields[5] = changeRate;            // PRDY_CTRT
+        fields[12] = contingentVolume;     // CNTG_VOL
+        fields[13] = accumulatedVolume;    // ACML_VOL
+        fields[21] = ccldDvsn;             // CCLD_DVSN
+        return fields;
+    }
+
+    private String buildData(String[]... items) {
+        List<String> allFields = new ArrayList<>();
+        for (String[] fields : items) {
+            allFields.addAll(Arrays.asList(fields));
+        }
+        return String.join("^", allFields);
+    }
+}


### PR DESCRIPTION
## 배경

- #140

## 작업 사항

- 한국투자증권 웹소켓 메시지 공통 처리 핸들러`KisWebSocketDispatcher` 구현 및 적용 | (0083a303baad0e69aca7c81ac5dcd303ffdedc89) (46311eff0888e41a42049c323da9484244841871)
  - **공통 처리 로직** →  메타 메시지(PingPong, 구독 응답)는 공통 처리 핸들러 내부에서 처리
  - **TR_ID 별 개별 처리 로직** → 실시간 데이터 응답은 `TR_ID` 기준으로 등록된 핸들러에게 위임
- 웹소켓 세션 연결 실패 시 예외처리 구문 추가 | (6868becf766f28c5ddc14c3d33b9f65cbd1f6484)
  - 연결 실패 시 `null` 대신 `KisApiException`을 던지도록 변경 & 호출부에서 예외 처리
- 한국투자증권 실시간 체결가(주식 시세) 응답 처리 핸들러 `KisStockQuoteWebSocketHandler` 구현 | (f938378ad9aeb3f9b8d6e2227961ca548722014c)
  - 체결 구분(`CCLD_DVSN`) 값을 매수/매도로 판별하고, 판별 불가 데이터는 알림 대상에서 제외
  - 응답 파싱/변환 실패 시 알림 대상에서 제외
- Dispatcher / 웹소켓 세션 커넥터 / 실시간 체결가 핸들러 테스트 코드 작성 | (72e2f74d718a7d01d7b23b68c95fe5a9c58feaec) (97210d0b32d803047fd923995c5de6879cfcf6c6) (004952f5d0a26a1b82725eb2e7b78ee9c89aa8e5)

### 📌 변경 후 한국투자증권 웹소켓 메시지 처리 구조 다이어그램


```
		+---------------------+
		|  한국투자증권 웹소켓 서버 |
		+---------------------+
			        |
			        |  TextMessage 응답
			        v
+------------------------------------+
|      KisWebSocketDispatcher        |
+------------------------------------+
| - Map<String, KisWebSocketHandler> |
+------------------------------------+   
			        |
			        |  TR_ID 기준 요청 위임
			        v 
+-------------------------------------------+
|            << interface >>                |
|          KisWebSocketHandler              |
+-------------------------------------------+
| + getTrId(): 처리 가능 TR_ID 반환            |
| + handle(Response): 응답 처리               |
+-------------------------------------------+
      ^							^				...
      |							|				...
      |							|				...
+------------------+  +------------------+
| KisStockQuote    |  | other            |
| WebSocketHandler |  | WebSocketHandler |
+------------------+  +------------------+  	...
| + getTrId()      |  | + getTrId()      |
| + handle(..)     |  | + handle(..)     |
+------------------+  +------------------+			         
```


## 추가사항 
- @gugitgugit 실시간 체결가 알림 DTO `TradeNotificationDto` 필드명 변경에 따라 FE에서도 응답값 필드 변경이 필요할 것 같습니다. | (f938378ad9aeb3f9b8d6e2227961ca548722014c)
  - `stockCount` → `contingentVolume`
  - `volume` → `accumulatedVolume`